### PR TITLE
Kotlin M13 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ buildscript {
 }
 
 dependencies {
-    compile 'fuel:fuel:0.52'
+    compile 'fuel:fuel:0.53'
 }
 ```
 

--- a/fuel/build.gradle
+++ b/fuel/build.gradle
@@ -15,7 +15,7 @@ android {
         minSdkVersion 9
         targetSdkVersion 23
         versionCode 1
-        versionName "0.52"
+        versionName "0.53"
     }
 
     sourceSets {
@@ -47,7 +47,7 @@ dependencies {
 buildscript {
     ext {
         //dependencies version
-        kotlin_version = '0.12.1230'
+        kotlin_version = '0.13.1513'
         junit_version = '4.12'
         robolectric_version = '3.0'
     }

--- a/fuel/src/main/kotlin/fuel/Fuel.kt
+++ b/fuel/src/main/kotlin/fuel/Fuel.kt
@@ -3,7 +3,6 @@ package fuel
 import fuel.core.Manager
 import fuel.core.Method
 import fuel.core.Request
-import kotlin.platform.platformStatic
 
 /**
  * Created by Kittinun Vantasin on 5/13/15.
@@ -23,67 +22,67 @@ public class Fuel {
 
         //convenience methods
         //get
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun get(path: String, parameters: Map<String, Any?>? = null): Request {
             return request(Method.GET, path, parameters)
         }
 
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun get(convertible: PathStringConvertible, parameters: Map<String, Any?>? = null): Request {
             return request(Method.GET, convertible, parameters)
         }
 
         //post
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun post(path: String, parameters: Map<String, Any?>? = null): Request {
             return request(Method.POST, path, parameters)
         }
 
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun post(convertible: PathStringConvertible, parameters: Map<String, Any?>? = null): Request {
             return request(Method.POST, convertible, parameters)
         }
 
         //put
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun put(path: String, parameters: Map<String, Any?>? = null): Request {
             return request(Method.PUT, path, parameters)
         }
 
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun put(convertible: PathStringConvertible, parameters: Map<String, Any?>? = null): Request {
             return request(Method.PUT, convertible, parameters)
         }
 
         //delete
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun delete(path: String, parameters: Map<String, Any?>? = null): Request {
             return request(Method.DELETE, path, parameters)
         }
 
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun delete(convertible: PathStringConvertible, parameters: Map<String, Any?>? = null): Request {
             return request(Method.DELETE, convertible, parameters)
         }
 
         //download
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun download(path: String, parameters: Map<String, Any?>? = null): Request {
             return Manager.instance.download(path, parameters)
         }
 
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun download(convertible: PathStringConvertible, parameters: Map<String, Any?>? = null): Request {
             return Manager.instance.download(convertible, parameters)
         }
 
         //upload
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun upload(path: String, parameters: Map<String, Any?>? = null): Request {
             return Manager.instance.upload(path, parameters)
         }
 
-        platformStatic jvmOverloads
+        @JvmStatic @JvmOverloads
         public fun upload(convertible: PathStringConvertible, parameters: Map<String, Any?>? = null): Request {
             return Manager.instance.upload(convertible, parameters)
         }
@@ -97,7 +96,7 @@ public class Fuel {
             return Manager.instance.request(method, convertible, parameters)
         }
 
-        platformStatic
+        @JvmStatic
         public fun request(convertible: RequestConvertible): Request {
             return Manager.instance.request(convertible)
         }
@@ -106,62 +105,62 @@ public class Fuel {
 
 }
 
-jvmOverloads
+@JvmOverloads
 public fun String.httpGet(parameters: Map<String, Any?>? = null): Request {
     return Fuel.get(this, parameters)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun Fuel.PathStringConvertible.httpGet(parameter: Map<String, Any?>? = null): Request {
     return Fuel.get(this, parameter)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun String.httpPost(parameters: Map<String, Any?>? = null): Request {
     return Fuel.post(this, parameters)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun Fuel.PathStringConvertible.httpPost(parameter: Map<String, Any?>? = null): Request {
     return Fuel.post(this, parameter)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun String.httpPut(parameters: Map<String, Any?>? = null): Request {
     return Fuel.put(this, parameters)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun Fuel.PathStringConvertible.httpPut(parameter: Map<String, Any?>? = null): Request {
     return Fuel.put(this, parameter)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun String.httpDelete(parameters: Map<String, Any?>? = null): Request {
     return Fuel.delete(this, parameters)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun Fuel.PathStringConvertible.httpDelete(parameter: Map<String, Any?>? = null): Request {
     return Fuel.delete(this, parameter)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun String.httpDownload(parameter: Map<String, Any?>? = null): Request {
     return Fuel.download(this, parameter)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun Fuel.PathStringConvertible.httpDownload(parameter: Map<String, Any?>? = null): Request {
     return Fuel.download(this, parameter)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun String.httpUpload(parameter: Map<String, Any?>? = null): Request {
     return Fuel.upload(this, parameter)
 }
 
-jvmOverloads
+@JvmOverloads
 public fun Fuel.PathStringConvertible.httpUpload(parameter: Map<String, Any?>? = null): Request {
     return Fuel.upload(this, parameter)
 }

--- a/fuel/src/main/kotlin/fuel/core/Deserializable.kt
+++ b/fuel/src/main/kotlin/fuel/core/Deserializable.kt
@@ -10,13 +10,13 @@ import java.io.Reader
  * Created by Kittinun Vantasin on 8/16/15.
  */
 
-private interface Deserializable<out T> {
+internal interface Deserializable<out T : Any> {
 
     fun deserialize(response: Response): T
 
 }
 
-public interface ResponseDeserializable<out T> : Deserializable<T> {
+public interface ResponseDeserializable<out T : Any> : Deserializable<T> {
 
     override fun deserialize(response: Response): T {
         return deserialize(response.data) ?:
@@ -37,7 +37,7 @@ public interface ResponseDeserializable<out T> : Deserializable<T> {
 
 }
 
-private fun <T, U : Deserializable<T>> Request.response(deserializable: U, handler: (Request, Response, Either<FuelError, T>) -> Unit) {
+internal fun <T, U : Deserializable<T>> Request.response(deserializable: U, handler: (Request, Response, Either<FuelError, T>) -> Unit) {
     response(deserializable, { request, response, value ->
         handler(this@response, response, Right(value))
     }, { request, response, error ->
@@ -45,7 +45,7 @@ private fun <T, U : Deserializable<T>> Request.response(deserializable: U, handl
     })
 }
 
-private fun <T, U : Deserializable<T>> Request.response(deserializable: U, handler: Handler<T>) {
+internal fun <T, U : Deserializable<T>> Request.response(deserializable: U, handler: Handler<T>) {
     response(deserializable, { request, response, value ->
         handler.success(request, response, value)
     }, { request, response, error ->
@@ -53,7 +53,7 @@ private fun <T, U : Deserializable<T>> Request.response(deserializable: U, handl
     })
 }
 
-private fun <T, U : Deserializable<T>> Request.response(deserializable: U,
+internal fun <T, U : Deserializable<T>> Request.response(deserializable: U,
                                                         success: (Request, Response, T) -> Unit,
                                                         failure: (Request, Response, FuelError) -> Unit) {
     build(taskRequest) {

--- a/fuel/src/main/kotlin/fuel/core/Either.kt
+++ b/fuel/src/main/kotlin/fuel/core/Either.kt
@@ -4,7 +4,7 @@ package fuel.core
  * Created by Kittinun Vantasin on 5/15/15.
  */
 
-suppress("BASE_WITH_NULLABLE_UPPER_BOUND")
+@Suppress("BASE_WITH_NULLABLE_UPPER_BOUND")
 abstract public class Either<out L, out R> {
 
     public abstract fun component1(): L?
@@ -27,7 +27,7 @@ abstract public class Either<out L, out R> {
     }
 
     public fun <X> get(): X {
-        @suppress("UNCHECKED_CAST")
+        @Suppress("UNCHECKED_CAST")
         return when (this) {
             is Left<L, R> -> this.left as X
             is Right<L, R> -> this.right as X

--- a/fuel/src/main/kotlin/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/fuel/core/Encoding.kt
@@ -50,12 +50,12 @@ public class Encoding : Fuel.RequestConvertible {
 
     }
 
-    override val request by Delegates.lazy { encoder(httpMethod, urlString, parameters) }
+    override val request by lazy { encoder(httpMethod, urlString, parameters) }
 
     private fun createUrl(path: String): URL {
         val pathUri = Uri.parse(path)
         //give precedence to local path
-        if (baseUrlString == null || pathUri.getScheme() != null) return URL(path)
+        if (baseUrlString == null || pathUri.scheme != null) return URL(path)
 
         //use basePath
         return URL(baseUrlString + if (path.startsWith('/')) path else '/' + path)

--- a/fuel/src/main/kotlin/fuel/core/Manager.kt
+++ b/fuel/src/main/kotlin/fuel/core/Manager.kt
@@ -26,7 +26,7 @@ public class Manager {
     public var executor: ExecutorService by Delegates.readWriteLazy {
         Executors.newCachedThreadPool { command ->
             Thread {
-                Thread.currentThread().setPriority(Thread.NORM_PRIORITY)
+                Thread.currentThread().priority = Thread.NORM_PRIORITY
                 command.run()
             }
         }

--- a/fuel/src/main/kotlin/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/fuel/core/Request.kt
@@ -45,7 +45,7 @@ public class Request {
     }
 
     //underlying task request
-    val taskRequest: TaskRequest by Delegates.lazy {
+    val taskRequest: TaskRequest by lazy(LazyThreadSafetyMode.NONE) {
         when (type) {
             Type.DOWNLOAD -> DownloadTaskRequest(this)
             Type.UPLOAD -> UploadTaskRequest(this)
@@ -189,9 +189,9 @@ public class Request {
     public fun responseJson(handler: Handler<JSONObject>): Unit = response(Request.jsonDeserializer(), handler)
 
     //object
-    public fun <T> responseObject(deserializer: ResponseDeserializable<T>, handler: (Request, Response, Either<FuelError, T>) -> Unit): Unit = response(deserializer, handler)
+    public fun <T: Any> responseObject(deserializer: ResponseDeserializable<T>, handler: (Request, Response, Either<FuelError, T>) -> Unit): Unit = response(deserializer, handler)
 
-    public fun <T> responseObject(deserializer: ResponseDeserializable<T>, handler: Handler<T>): Unit = response(deserializer, handler)
+    public fun <T: Any> responseObject(deserializer: ResponseDeserializable<T>, handler: Handler<T>): Unit = response(deserializer, handler)
 
     public fun cUrlString(): String {
         val elements = arrayListOf("$ curl -i")
@@ -337,9 +337,9 @@ public class Request {
 
                 dataStream = build(ByteArrayOutputStream()) {
                     write(("--" + boundary + CRLF).toByteArray())
-                    write(("Content-Disposition: form-data; filename=\"" + file.getName() + "\"").toByteArray())
+                    write(("Content-Disposition: form-data; filename=\"" + file.name + "\"").toByteArray())
                     write(CRLF.toByteArray())
-                    write(("Content-Type: " + URLConnection.guessContentTypeFromName(file.getName())).toByteArray())
+                    write(("Content-Type: " + URLConnection.guessContentTypeFromName(file.name)).toByteArray())
                     write(CRLF.toByteArray())
                     write(CRLF.toByteArray())
                     flush()
@@ -351,7 +351,7 @@ public class Request {
 
                     write(CRLF.toByteArray())
                     flush()
-                    write(("--" + boundary + "--").toByteArray())
+                    write(("--$boundary--").toByteArray())
                     write(CRLF.toByteArray())
                     flush()
                 }

--- a/fuel/src/main/kotlin/fuel/util/Delegates.kt
+++ b/fuel/src/main/kotlin/fuel/util/Delegates.kt
@@ -13,15 +13,15 @@ private class ReadWriteLazyVal<T>(private val initializer: () -> T) : ReadWriteP
 
     private var value: Any? = null
 
-    public override fun get(thisRef: Any?, desc: PropertyMetadata): T {
+    public override fun get(thisRef: Any?, property: PropertyMetadata): T {
         if (value == null) {
-            value = (initializer()) ?: throw IllegalStateException("Initializer block of property ${desc.name} return null")
+            value = (initializer()) ?: throw IllegalStateException("Initializer block of property ${property.name} return null")
         }
-        @suppress("UNCHECKED_CAST")
+        @Suppress("UNCHECKED_CAST")
         return value as T
     }
 
-    override fun set(thisRef: Any?, desc: PropertyMetadata, value: T) {
+    override fun set(thisRef: Any?, property: PropertyMetadata, value: T) {
         this.value = value
     }
 

--- a/fuel/src/test/kotlin/fuel/BaseTestCase.kt
+++ b/fuel/src/test/kotlin/fuel/BaseTestCase.kt
@@ -10,8 +10,8 @@ import kotlin.properties.Delegates
  * Created by Kittinun Vantasin on 5/21/15.
  */
 
-RunWith(CustomRobolectricGradleTestRunner::class)
-Config(constants = BuildConfig::class, sdk = intArrayOf(21))
+@RunWith(CustomRobolectricGradleTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = intArrayOf(21))
 abstract class BaseTestCase {
 
     val DEFAULT_TIMEOUT = 15L
@@ -19,7 +19,7 @@ abstract class BaseTestCase {
     var lock: CountDownLatch by Delegates.notNull()
 
     fun await(seconds: Long = DEFAULT_TIMEOUT) {
-        lock.await(seconds, TimeUnit.SECONDS);
+        lock.await(seconds, TimeUnit.SECONDS)
     }
 
 }

--- a/fuel/src/test/kotlin/fuel/CustomRobolectricGradleTestRunner.kt
+++ b/fuel/src/test/kotlin/fuel/CustomRobolectricGradleTestRunner.kt
@@ -13,15 +13,15 @@ public class CustomRobolectricGradleTestRunner(clazz: Class<*>) : RobolectricGra
 
     override fun getAppManifest(config: Config): AndroidManifest {
         val appManifest = super.getAppManifest(config)
-        var androidManifestFile = appManifest.getAndroidManifestFile()
+        var androidManifestFile = appManifest.androidManifestFile
 
         if (androidManifestFile.exists()) {
             return appManifest
         } else {
             val moduleRoot = getModuleRootPath(config)
-            androidManifestFile = FileFsFile.from(moduleRoot, appManifest.getAndroidManifestFile().getPath())
-            val resDirectory = FileFsFile.from(moduleRoot, appManifest.getAndroidManifestFile().getPath().replace("AndroidManifest.xml", "res"))
-            val assetsDirectory = FileFsFile.from(moduleRoot, appManifest.getAndroidManifestFile().getPath().replace("AndroidManifest.xml", "assets"))
+            androidManifestFile = FileFsFile.from(moduleRoot, appManifest.androidManifestFile.path)
+            val resDirectory = FileFsFile.from(moduleRoot, appManifest.androidManifestFile.path.replace("AndroidManifest.xml", "res"))
+            val assetsDirectory = FileFsFile.from(moduleRoot, appManifest.androidManifestFile.path.replace("AndroidManifest.xml", "assets"))
             return AndroidManifest(androidManifestFile, resDirectory, assetsDirectory)
         }
     }

--- a/fuel/src/test/kotlin/fuel/RequestAuthenticationTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestAuthenticationTest.kt
@@ -26,7 +26,7 @@ class RequestAuthenticationTest : BaseTestCase() {
         password = "password"
     }
 
-    val manager: Manager by Delegates.lazy {
+    val manager: Manager by lazy(LazyThreadSafetyMode.NONE) {
         build(Manager()) {
             basePath = "http://httpbin.org"
             callbackExecutor = object : Executor {
@@ -37,12 +37,12 @@ class RequestAuthenticationTest : BaseTestCase() {
         }
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpBasicAuthenticationWithInvalidCase() {
         var request: Request? = null
         var response: Response? = null
@@ -70,7 +70,7 @@ class RequestAuthenticationTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code of invalid credential should be $statusCode")
     }
 
-    Test
+    @Test
     fun httpBasicAuthenticationWithValidCase() {
         var request: Request? = null
         var response: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestDownloadTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestDownloadTest.kt
@@ -12,7 +12,6 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
-import kotlin.properties.Delegates
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -23,7 +22,7 @@ import kotlin.test.assertTrue
 
 class RequestDownloadTest : BaseTestCase() {
 
-    val manager: Manager by Delegates.lazy {
+    val manager: Manager by lazy {
         build(Manager()) {
             basePath = "http://httpbin.org"
             callbackExecutor = object : Executor {
@@ -34,12 +33,12 @@ class RequestDownloadTest : BaseTestCase() {
         }
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpDownloadCase() {
         var request: Request? = null
         var response: Response? = null
@@ -50,7 +49,7 @@ class RequestDownloadTest : BaseTestCase() {
 
         manager.download("/bytes/$numberOfBytes").destination { response, url ->
             val f = File.createTempFile(numberOfBytes.toString(), null)
-            println(f.getAbsolutePath())
+            println(f.absolutePath)
             f
         }.responseString { req, res, either ->
             request = req
@@ -72,7 +71,7 @@ class RequestDownloadTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode")
     }
 
-    Test
+    @Test
     fun httpDownloadWithProgressValidCase() {
         var request: Request? = null
         var response: Response? = null
@@ -85,7 +84,7 @@ class RequestDownloadTest : BaseTestCase() {
         val numberOfBytes = 1048576L
         manager.download("/bytes/$numberOfBytes").destination { response, url ->
             val f = File.createTempFile(numberOfBytes.toString(), null)
-            println(f.getAbsolutePath())
+            println(f.absolutePath)
             f
         }.progress { readBytes, totalBytes ->
             read = readBytes
@@ -113,7 +112,7 @@ class RequestDownloadTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode")
     }
 
-    Test
+    @Test
     fun httpDownloadWithProgressInvalidEndPointCase() {
         var request: Request? = null
         var response: Response? = null
@@ -123,7 +122,7 @@ class RequestDownloadTest : BaseTestCase() {
         val numberOfBytes = 131072
         manager.download("/byte/$numberOfBytes").destination { response, url ->
             val f = File.createTempFile(numberOfBytes.toString(), null)
-            println(f.getAbsolutePath())
+            println(f.absolutePath)
             f
         }.progress { readBytes, totalBytes ->
 
@@ -148,7 +147,7 @@ class RequestDownloadTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode")
     }
 
-    Test
+    @Test
     fun httpDownloadWithProgressInvalidFileCase() {
         var request: Request? = null
         var response: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestHandlerTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestHandlerTest.kt
@@ -39,7 +39,8 @@ class RequestHandlerTest : BaseTestCase() {
             val results = hashMapOf<String, String>()
 
             val jsonHeaders = JSONObject(content).getJSONObject("headers")
-            jsonHeaders.keys().asSequence().fold(results) { results, key ->
+            @Suppress("UNCHECKED_CAST")
+            (jsonHeaders.keys().asSequence() as Sequence<String>).fold(results) { results, key ->
                 results.put(key, jsonHeaders.getString(key))
                 results
             }
@@ -52,12 +53,12 @@ class RequestHandlerTest : BaseTestCase() {
 
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpGetRequestValid() {
         var req: Request? = null
         var res: Response? = null
@@ -89,7 +90,7 @@ class RequestHandlerTest : BaseTestCase() {
         assertTrue(res?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpGetRequestInvalid() {
         var req: Request? = null
         var res: Response? = null
@@ -121,7 +122,7 @@ class RequestHandlerTest : BaseTestCase() {
         assertTrue(res?.httpStatusCode == HttpURLConnection.HTTP_NOT_FOUND, "http status code (${res?.httpStatusCode}) should be ${HttpURLConnection.HTTP_NOT_FOUND}")
     }
 
-    Test
+    @Test
     fun httpPostRequestWithParameters() {
         var req: Request? = null
         var res: Response? = null
@@ -158,7 +159,7 @@ class RequestHandlerTest : BaseTestCase() {
         assertTrue(string.contains(paramKey) && string.contains(paramValue), "url query param should be sent along with url and present in response of httpbin.org")
     }
 
-    Test
+    @Test
     fun httpGetRequestJsonValid() {
         var req: Request? = null
         var res: Response? = null
@@ -189,7 +190,7 @@ class RequestHandlerTest : BaseTestCase() {
         assertTrue(res?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpGetRequestJsonInvalid() {
         var req: Request? = null
         var res: Response? = null
@@ -219,7 +220,7 @@ class RequestHandlerTest : BaseTestCase() {
         assertTrue(res?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code (${res?.httpStatusCode}) should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpGetRequestObject() {
         var req: Request? = null
         var res: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestHeaderTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestHeaderTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertTrue
 
 class RequestHeaderTest : BaseTestCase() {
 
-    val manager: Manager by Delegates.lazy {
+    val manager: Manager by lazy {
         build(Manager()) {
             basePath = "http://httpbin.org"
             callbackExecutor = object : Executor {
@@ -29,12 +29,12 @@ class RequestHeaderTest : BaseTestCase() {
         }
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpRequestHeader() {
         var request: Request? = null
         var response: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestObjectTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestObjectTest.kt
@@ -46,12 +46,12 @@ class RequestObjectTest : BaseTestCase() {
 
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpRequestObjectUserAgentValidTest() {
         var request: Request? = null
         var response: Response? = null
@@ -79,7 +79,7 @@ class RequestObjectTest : BaseTestCase() {
         assertTrue((data as HttpBinUserAgentModel).userAgent.isNotBlank(), "model must properly be serialized")
     }
 
-    Test
+    @Test
     fun httpRequestObjectUserAgentInvalidTest() {
         var request: Request? = null
         var response: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestPathStringConvertibleExtensionTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestPathStringConvertibleExtensionTest.kt
@@ -37,12 +37,12 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         override val path = "/$relativePath"
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpGetRequestWithSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -69,7 +69,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpPostRequestWithSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -100,7 +100,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertTrue(string.contains("https"), "url should contain https to indicate usage of shared instance")
     }
 
-    Test
+    @Test
     fun httpPutRequestWithSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -131,7 +131,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertTrue(string.contains("https"), "url should contain https to indicate usage of shared instance")
     }
 
-    Test
+    @Test
     fun httpDeleteRequestWithSharedInstance() {
         var request: Request? = null
         var response: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestSharedInstanceTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestSharedInstanceTest.kt
@@ -50,12 +50,12 @@ class RequestSharedInstanceTest : BaseTestCase() {
         }
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpGetRequestWithSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -87,7 +87,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(string.contains("https"), "url should contain https to indicate usage of shared instance")
     }
 
-    Test
+    @Test
     fun httpPostRequestWithSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -120,7 +120,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(string.contains("https"), "url should contain https to indicate usage of shared instance")
     }
 
-    Test
+    @Test
     fun httpPutRequestWithSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -153,7 +153,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(string.contains("https"), "url should contain https to indicate usage of shared instance")
     }
 
-    Test
+    @Test
     fun httpDeleteRequestWithSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -186,7 +186,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(string.contains("https"), "url should contain https to indicate usage of shared instance")
     }
 
-    Test
+    @Test
     fun httpGetRequestWithPathStringConvertibleAndSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -217,7 +217,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(string.contains("origin"), "response should contain \"origin\" ")
     }
 
-    Test
+    @Test
     fun httpPostRequestWithPathStringConvertibleAndSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -248,7 +248,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(string.contains("https"), "url should contain https to indicate usage of shared instance")
     }
 
-    Test
+    @Test
     fun httpPutRequestWithPathStringConvertibleAndSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -279,7 +279,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(string.contains("https"), "url should contain https to indicate usage of shared instance")
     }
 
-    Test
+    @Test
     fun httpDeleteRequestWithPathStringConvertibleAndSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -310,7 +310,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(string.contains("https"), "url should contain https to indicate usage of shared instance")
     }
 
-    Test
+    @Test
     fun httpGetRequestWithRequestConvertibleAndSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -337,7 +337,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpPostRequestWithRequestConvertibleAndSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -364,7 +364,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpPutRequestWithRequestConvertibleAndSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -391,7 +391,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpDeleteRequestWithRequestConvertibleAndSharedInstance() {
         var request: Request? = null
         var response: Response? = null
@@ -418,7 +418,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpUploadWithProgressValidCase() {
         var request: Request? = null
         var response: Response? = null
@@ -454,11 +454,11 @@ class RequestSharedInstanceTest : BaseTestCase() {
 
         assertTrue(read == total && read != -1L && total != -1L, "read bytes and total bytes should be equal")
         val statusCode = HttpURLConnection.HTTP_OK
-        assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode" )
+        assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode")
     }
 
 
-    Test
+    @Test
     fun httpDownloadWithProgressValidCase() {
         var request: Request? = null
         var response: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestStringExtensionTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestStringExtensionTest.kt
@@ -31,12 +31,12 @@ class RequestStringExtensionTest : BaseTestCase() {
         }
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpGet() {
         var request: Request? = null
         var response: Response? = null
@@ -64,7 +64,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode" )
     }
 
-    Test
+    @Test
     fun httpPost() {
         var request: Request? = null
         var response: Response? = null
@@ -92,7 +92,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode" )
     }
 
-    Test
+    @Test
     fun httpPut() {
         var request: Request? = null
         var response: Response? = null
@@ -120,7 +120,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode" )
     }
 
-    Test
+    @Test
     fun httpDelete() {
         var request: Request? = null
         var response: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import java.net.HttpURLConnection
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
-import kotlin.properties.Delegates
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -19,7 +18,7 @@ import kotlin.test.assertTrue
 
 class RequestTest : BaseTestCase() {
 
-    val manager: Manager by Delegates.lazy {
+    val manager: Manager by lazy {
         build(Manager()) {
             callbackExecutor = object : Executor {
                 override fun execute(command: Runnable) {
@@ -38,7 +37,7 @@ class RequestTest : BaseTestCase() {
         override val path = "https://httpbin.org/$relativePath"
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
@@ -56,7 +55,7 @@ class RequestTest : BaseTestCase() {
         }
     }
 
-    Test
+    @Test
     fun httpGetRequestWithDataResponse() {
         var request: Request? = null
         var response: Response? = null
@@ -84,7 +83,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpGetRequestWithStringResponse() {
         var request: Request? = null
         var response: Response? = null
@@ -112,7 +111,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpGetRequestWithJsonObjectResponse() {
         var request: Request? = null
         var response: Response? = null
@@ -140,7 +139,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpGetRequestWithParameters() {
         var request: Request? = null
         var response: Response? = null
@@ -174,7 +173,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(string.contains(paramKey) && string.contains(paramValue), "url query param should be sent along with url and present in response of httpbin.org")
     }
 
-    Test
+    @Test
     fun httpPostRequestWithParameters() {
         var request: Request? = null
         var response: Response? = null
@@ -208,7 +207,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(string.contains(paramKey) && string.contains(paramValue), "url query param should be sent along with url and present in response of httpbin.org")
     }
 
-    Test
+    @Test
     fun httpPostRequestWithBody() {
         var request: Request? = null
         var response: Response? = null
@@ -241,7 +240,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(string.contains("foo") && string.contains("bar"), "body should be sent along with url and present in response of httpbin.org")
     }
 
-    Test
+    @Test
     fun httpPutRequestWithParameters() {
         var request: Request? = null
         var response: Response? = null
@@ -275,7 +274,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(string.contains(paramKey) && string.contains(paramValue), "url query param should be sent along with url and present in response of httpbin.org")
     }
 
-    Test
+    @Test
     fun httpDeleteRequestWithParameters() {
         var request: Request? = null
         var response: Response? = null
@@ -309,7 +308,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(string.contains(paramKey) && string.contains(paramValue), "url query param should be sent along with url and present in response of httpbin.org")
     }
 
-    Test
+    @Test
     fun httpGetRequestWithPathStringConvertible() {
         var request: Request? = null
         var response: Response? = null
@@ -339,7 +338,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(string.contains("user-agent"), "USER_AGENT endpoint must be resolved correctly, and user-agent should be present in this response")
     }
 
-    Test
+    @Test
     fun httpGetRequestWithRequestConvertible() {
         var request: Request? = null
         var response: Response? = null
@@ -368,7 +367,7 @@ class RequestTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == HttpURLConnection.HTTP_OK, "http status code should be ${HttpURLConnection.HTTP_OK}")
     }
 
-    Test
+    @Test
     fun httpGetRequestWithRequestConvertibleAndOverriddenParameters() {
         var request: Request? = null
         var response: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestUploadTest.kt
@@ -23,7 +23,7 @@ import kotlin.test.assertTrue
 
 class RequestUploadTest : BaseTestCase() {
 
-    val manager: Manager by Delegates.lazy {
+    val manager: Manager by lazy {
         build(Manager()) {
             basePath = "http://httpbin.org"
             callbackExecutor = object : Executor {
@@ -34,17 +34,17 @@ class RequestUploadTest : BaseTestCase() {
         }
     }
 
-    val currentDir: File by Delegates.lazy {
+    val currentDir: File by lazy {
         val dir = System.getProperty("user.dir")
         File(dir, "src/test/assets")
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpUploadCase() {
         var request: Request? = null
         var response: Response? = null
@@ -73,7 +73,7 @@ class RequestUploadTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode")
     }
 
-    Test
+    @Test
     fun httpUploadWithProgressValidCase() {
         var request: Request? = null
         var response: Response? = null
@@ -111,7 +111,7 @@ class RequestUploadTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode")
     }
 
-    Test
+    @Test
     fun httpUploadWithProgressInvalidEndPointCase() {
         var request: Request? = null
         var response: Response? = null
@@ -143,7 +143,7 @@ class RequestUploadTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == statusCode, "http status code should be $statusCode")
     }
 
-    Test
+    @Test
     fun httpUploadWithProgressInvalidFileCase() {
         var request: Request? = null
         var response: Response? = null

--- a/fuel/src/test/kotlin/fuel/RequestValidationTest.kt
+++ b/fuel/src/test/kotlin/fuel/RequestValidationTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 
 class RequestValidationTest : BaseTestCase() {
 
-    val manager: Manager by Delegates.lazy {
+    val manager: Manager by lazy(LazyThreadSafetyMode.NONE) {
         build(Manager()) {
             basePath = "http://httpbin.org"
             callbackExecutor = object : Executor {
@@ -28,12 +28,12 @@ class RequestValidationTest : BaseTestCase() {
         }
     }
 
-    Before
+    @Before
     fun setUp() {
         lock = CountDownLatch(1)
     }
 
-    Test
+    @Test
     fun httpValidationWithDefaultCase() {
         val preDefinedStatusCode = 418
 
@@ -64,7 +64,7 @@ class RequestValidationTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == preDefinedStatusCode, "http status code should be $preDefinedStatusCode")
     }
 
-    Test
+    @Test
     fun httpValidationWithCustomValidCase() {
         val preDefinedStatusCode = 203
 
@@ -94,7 +94,7 @@ class RequestValidationTest : BaseTestCase() {
         assertTrue(response?.httpStatusCode == preDefinedStatusCode, "http status code should be $preDefinedStatusCode")
     }
 
-    Test
+    @Test
     fun httpValidationWithCustomInvalidCase() {
         val preDefineStatusCode = 418
 


### PR DESCRIPTION
I've converted the project to Kotlin M13. (fixes #19 )
In some places it uses `lazy(LazyThreadSafetyMode.NONE)` instead of just `lazy`. That is because the automatic fix on all the project. I think it works the same as `lazy`, so you can replace it later.
Also, in order to remove a warning, I've added `Method.PATCH` to the when expression. However, `Method.PATCH` is inaccessible as a method, so it doesn't actually change something.

```kotlin
private fun setDoOutput(connection: HttpURLConnection, method: Method) {
         when (method) {
            Method.GET, Method.DELETE -> connection.doOutput = false
            Method.POST, Method.PUT, Method.PATCH -> connection.doOutput = true
         }
     }
```

Also I've run the tests, all pass. So it looks like no functionality were changed.