### PR TITLE
Synchronous call support

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
@@ -82,9 +82,7 @@ private fun <T : Any, U : Deserializable<T>> Request.response(deserializable: U,
 
     submit(taskRequest)
 
-    if (this.syncMode) {
-        this.taskFuture?.get(this.timeoutInMillisecond.toLong(), MILLISECONDS)
-    }
+    if (syncMode) taskFuture?.get(timeoutInMillisecond.toLong(), MILLISECONDS)
 
     return this
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
@@ -5,6 +5,7 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.Reader
+import java.util.concurrent.TimeUnit.MILLISECONDS
 
 /**
  * Created by Kittinun Vantasin on 8/16/15.
@@ -80,6 +81,10 @@ private fun <T : Any, U : Deserializable<T>> Request.response(deserializable: U,
     }
 
     submit(taskRequest)
+
+    if (this.syncMode) {
+        this.taskFuture?.get(this.timeoutInMillisecond.toLong(), MILLISECONDS)
+    }
 
     return this
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -29,6 +29,7 @@ public class Request {
     }
 
     val timeoutInMillisecond = 15000
+    var syncMode = false
 
     var type: Type = Type.REQUEST
     lateinit var httpMethod: Method
@@ -54,7 +55,7 @@ public class Request {
         }
     }
 
-    private var taskFuture: Future<Unit>? = null
+    public var taskFuture: Future<Unit>? = null
 
     //configuration
     var socketFactory: SSLSocketFactory? = null
@@ -81,6 +82,11 @@ public class Request {
                 }
             }
         }
+    }
+
+    public fun sync(): Request {
+        syncMode = true
+        return this
     }
 
     //interfaces

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -402,8 +402,6 @@ class RequestTest : BaseTestCase() {
         }
 
         // Then
-        println(request.cUrlString())
-        assertNotNull(request, "request should not be null")
         assertThat(received, notNullValue())
         assertThat(received?.response, notNullValue())
         assertThat(received?.response?.httpStatusCode, `is`(200))

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -1,6 +1,8 @@
 package com.github.kittinunf.fuel
 
 import com.github.kittinunf.fuel.core.*
+import org.hamcrest.CoreMatchers.*
+import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Test
 import java.net.HttpURLConnection
@@ -387,4 +389,27 @@ class RequestTest : BaseTestCase() {
         assertNull(error, "error should be null")
     }
 
+    @Test
+    fun httpGetSyncRequest() {
+        // Given
+        var expectedHost = "httpbin.org"
+        var received:Received? = null
+
+        // When
+        val request = manager.request(Method.GET, "http://${expectedHost}/get").sync().responseString { req, res, result ->
+            received = Received(res, result.value, result.error)
+            println("Received data")
+        }
+
+        // Then
+        println(request.cUrlString())
+        assertNotNull(request, "request should not be null")
+        assertThat(received, notNullValue())
+        assertThat(received?.response, notNullValue())
+        assertThat(received?.response?.httpStatusCode, `is`(200))
+        assertThat(received?.data as String, containsString(expectedHost))
+        assertThat(received?.error, nullValue())
+    }
 }
+
+data class Received(val response:Response? = null, val data: Any? = null, val error:FuelError? = null)

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -398,7 +398,6 @@ class RequestTest : BaseTestCase() {
         // When
         val request = manager.request(Method.GET, "http://${expectedHost}/get").sync().responseString { req, res, result ->
             received = Received(res, result.value, result.error)
-            println("Received data")
         }
 
         // Then


### PR DESCRIPTION
Introduced synchronous call support by adding sync() method to Request class.
When called during the flow API, a flag will be set to indicate that sync mode is to be use.
This flag is checked after the request submission and, if flagged, then future will make use of [get](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Future.html#get()) method to wait for request completion.