### PR TITLE
Optimize the imports in unittests

### DIFF
--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
@@ -1,7 +1,11 @@
 package com.github.kittinunf.fuel
 
-import com.github.kittinunf.fuel.core.*
-import org.hamcrest.CoreMatchers.*
+import com.github.kittinunf.fuel.core.Encoding
+import com.github.kittinunf.fuel.core.Manager
+import com.github.kittinunf.fuel.core.Method
+import com.github.kittinunf.fuel.core.Request
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.notNullValue
 import org.junit.Assert.assertThat
 import org.junit.Test
 import java.net.HttpURLConnection

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestDownloadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestDownloadTest.kt
@@ -1,6 +1,9 @@
 package com.github.kittinunf.fuel
 
-import com.github.kittinunf.fuel.core.*
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Manager
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
 import org.hamcrest.CoreMatchers.*
 import org.junit.Assert.assertThat
 import org.junit.Before

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestPathStringConvertibleExtensionTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestPathStringConvertibleExtensionTest.kt
@@ -1,6 +1,9 @@
 package com.github.kittinunf.fuel
 
-import com.github.kittinunf.fuel.core.*
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Manager
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
 import org.hamcrest.CoreMatchers.*
 import org.junit.Assert.assertThat
 import org.junit.Before


### PR DESCRIPTION
There is no need to `import .*` 