### PR TITLE
Update 'Synchronous Call' documentation in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,16 +355,10 @@ request.cancel()
 ```
 
 ### Synchronous Call 
-* Fuel supports synchronous call by calling `sync` before `response`. 
+* Fuel supports synchronous call by calling the `response()` methods without handler. 
 ``` Kotlin
-var data: String? = null
 //the call will block until the http call finished
-Fuel.get("http://httpbin.org/get").sync().responseString { req, res, result ->
-    val (d, e) = result
-    data = d
-}
-
-//do something with data
+var (req, res, result) = Fuel.get("http://httpbin.org/get").sync().responseString()
 ```
 
 ## Advanced Configuration

--- a/README.md
+++ b/README.md
@@ -354,13 +354,6 @@ val request = Fuel.get("http://httpbin.org/get").interrupt { request ->
 request.cancel()
 ```
 
-### Synchronous Call 
-* Fuel supports synchronous call by calling the `response()` methods without handler. 
-``` Kotlin
-//the call will block until the http call finished
-var (req, res, result) = Fuel.get("http://httpbin.org/get").sync().responseString()
-```
-
 ## Advanced Configuration
 
 ### Response Deserialization


### PR DESCRIPTION
Just lost 5 minutes searching the sync() method.
Do not hesitate to cancel this PR and improve the documentation on your side if you want to (it's just an easy-fix for you anyway).