### PR TITLE
Make sync version support Result<Data, FuelError>

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,9 @@ Fuel.get("http://httpbin.org/get", params).responseString(new Handler<String>() 
 #### Blocking mode
 You can also wait for the response. It returns the same parameters as the async version, but it blocks the thread. It supports all the features of the async version.
 
-**Note:** Instead of returning `Result` object, it will throw the exception.
-
 * Kotlin
 ``` Kotlin
-val (request, response, data) = "http://httpbin.org/get".httpGet().responseString()
+val (request, response, result) = "http://httpbin.org/get".httpGet().responseString() // result is Result<String, FuelError>
 ```
 
 * Java
@@ -115,7 +113,7 @@ try {
     Triple<Request, Response, String> data = Fuel.get("http://www.google.com").responseString();
     Request request = data.getFirst();
     Response response = data.getSecond();
-    String text = data.getThird();
+    Result<String,FuelError> text = data.getThird();
 } catch (Exception networkError) {
 
 }
@@ -352,19 +350,6 @@ val request = Fuel.get("http://httpbin.org/get").interrupt { request ->
 }
 
 request.cancel()
-```
-
-### Synchronous Call 
-* Fuel supports synchronous call by calling `sync` before `response`. 
-``` Kotlin
-var data: String? = null
-//the call will block until the http call finished
-Fuel.get("http://httpbin.org/get").sync().responseString { req, res, result ->
-    val (d, e) = result
-    data = d
-}
-
-//do something with data
 ```
 
 ## Advanced Configuration

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
@@ -42,7 +42,7 @@ class BlockingRequestTest : BaseTestCase() {
         val (request, response, data) = manager.request(Method.GET, "http://httpbin.org/get").response()
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
@@ -54,7 +54,7 @@ class BlockingRequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
@@ -69,13 +69,13 @@ class BlockingRequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
 
-        assertThat(data, containsString(paramKey))
-        assertThat(data, containsString(paramValue))
+        assertThat(data.get(), containsString(paramKey))
+        assertThat(data.get(), containsString(paramValue))
     }
 
     @Test
@@ -86,13 +86,13 @@ class BlockingRequestTest : BaseTestCase() {
         val (request, response, data) = manager.request(Method.GET, "http://httpbin.org/get", listOf(paramKey to paramValue)).responseString()
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
 
-        assertThat(data, containsString(paramKey))
-        assertThat(data, containsString(paramValue))
+        assertThat(data.get(), containsString(paramKey))
+        assertThat(data.get(), containsString(paramValue))
     }
 
     @Test
@@ -105,13 +105,13 @@ class BlockingRequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
 
-        assertThat(data, containsString(foo))
-        assertThat(data, containsString(bar))
+        assertThat(data.get(), containsString(foo))
+        assertThat(data.get(), containsString(bar))
     }
 
     @Test
@@ -123,13 +123,13 @@ class BlockingRequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
 
-        assertThat(data, containsString(paramKey))
-        assertThat(data, containsString(paramValue))
+        assertThat(data.get(), containsString(paramKey))
+        assertThat(data.get(), containsString(paramValue))
     }
 
     @Test
@@ -141,13 +141,13 @@ class BlockingRequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
 
-        assertThat(data, containsString(paramKey))
-        assertThat(data, containsString(paramValue))
+        assertThat(data.get(), containsString(paramKey))
+        assertThat(data.get(), containsString(paramValue))
     }
 
     @Test
@@ -156,12 +156,12 @@ class BlockingRequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
 
-        assertThat(data, containsString("user-agent"))
+        assertThat(data.get(), containsString("user-agent"))
     }
 
     @Test
@@ -170,7 +170,7 @@ class BlockingRequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
@@ -185,13 +185,13 @@ class BlockingRequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))
 
-        assertThat(data, containsString(paramKey))
-        assertThat(data, containsString(paramValue))
+        assertThat(data.get(), containsString(paramKey))
+        assertThat(data.get(), containsString(paramValue))
     }
 
     @Test
@@ -204,7 +204,7 @@ class BlockingRequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
-        assertThat(data, notNullValue())
+        assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response.httpStatusCode, isEqualTo(statusCode))


### PR DESCRIPTION
Now it has the same API is async version, allows you query the `Request` object even if the request has failed.

