### PR TITLE
Fix Encoding issue

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -5,6 +5,7 @@ import com.github.kittinunf.fuel.util.toHexString
 import java.net.MalformedURLException
 import java.net.URI
 import java.net.URL
+import java.net.URISyntaxException
 import kotlin.properties.Delegates
 
 class Encoding : Fuel.RequestConvertible {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -54,8 +54,12 @@ class Encoding : Fuel.RequestConvertible {
         } catch (e: MalformedURLException) {
             URL(baseUrlString + if (path.startsWith('/') or path.isEmpty()) path else '/' + path)
         }
-        val uri = URI(url.protocol, url.userInfo, url.host, url.port, url.path, url.query, url.ref)
-        return uri.toURL()
+        val uri = try {
+                    url.toURI()
+                } catch (e: URISyntaxException) {
+                    URI(url.protocol, url.userInfo, url.host, url.port, url.path, url.query, url.ref)
+                }
+        return URL(uri.toASCIIString())
     }
 
     private fun encodeParameterInUrl(method: Method): Boolean {

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/EncodingTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/EncodingTest.kt
@@ -104,4 +104,30 @@ class EncodingTest : BaseTestCase() {
         assertThat(request.url.toString(), isEqualTo("http://www.example.com/U$3%7C2%7C%5C%7C@me/P@$\$vv0%7C2%7C)"))
     }
 
+    @Test
+    fun testEncodingAlreadyEncodedUrl() {
+        val supposed = "https://www.example.com/files/%D7%98%D7%A7%D7%A1%D7%98%20%D7%91%D7%A2%D7%91%D7%A8%D7%99%D7%AA%201%203.txt"
+        val request = Encoding().apply {
+            httpMethod = Method.GET
+            urlString = supposed
+        }.request
+
+        assertThat(request.url.toString(), isEqualTo(supposed))
+    }
+
+    @Test
+    fun testEncodingNonAsciiString() {
+        val hebrewString = "טקסט בעברית 1 3.txt"
+        val path = "https://www.example.com/files/" + hebrewString
+
+        val request = Encoding().apply {
+            httpMethod = Method.GET
+            urlString = path
+            parameters = null
+        }.request
+
+        val supposed = "https://www.example.com/files/%D7%98%D7%A7%D7%A1%D7%98%20%D7%91%D7%A2%D7%91%D7%A8%D7%99%D7%AA%201%203.txt"
+        assertThat(request.url.toString(), isEqualTo(supposed))
+    }
+
 }


### PR DESCRIPTION
Should fix some encoding issues, check the added tests for extra details.

Example for URLs that works now:
`https://www.example.com/files/%D7%98%D7%A7%D7%A1%D7%98%20%D7%91%D7%A2%D7%91%D7%A8%D7%99%D7%AA%201%203.txt`

`https://www.example.com/files/טקסט בעברית 1 3.txt`