### PR TITLE
Interceptors

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
@@ -80,6 +80,6 @@ fun <T : Any, U : Deserializable<T>> Request.response(deserializable: U): Triple
         val response = taskRequest.call()
         return Triple(this, response, Result.Success(deserializable.deserialize(response)))
     } catch (error: FuelError) {
-        return Triple(this, Response().apply { url = this@response.url }, Result.error(error))
+        return Triple(this, error.response, Result.error(error))
     }
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -4,11 +4,12 @@ import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.util.toHexString
 import java.net.MalformedURLException
 import java.net.URI
-import java.net.URL
 import java.net.URISyntaxException
+import java.net.URL
 import kotlin.properties.Delegates
 
 class Encoding : Fuel.RequestConvertible {
+
     var requestType: Request.Type = Request.Type.REQUEST
     var httpMethod: Method by Delegates.notNull()
     var baseUrlString: String? = null
@@ -77,4 +78,5 @@ class Encoding : Fuel.RequestConvertible {
                     .joinToString("&")
         } ?: ""
     }
+
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Manager.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Manager.kt
@@ -1,6 +1,8 @@
 package com.github.kittinunf.fuel.core
 
 import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.interceptors.redirectResponseInterceptor
+import com.github.kittinunf.fuel.core.interceptors.validatorResponseInterceptor
 import com.github.kittinunf.fuel.toolbox.HttpClient
 import com.github.kittinunf.fuel.util.SameThreadExecutorService
 import com.github.kittinunf.fuel.util.readWriteLazy
@@ -12,6 +14,7 @@ import java.util.concurrent.Executors
 import javax.net.ssl.*
 
 class Manager {
+
     var client: Client by readWriteLazy { HttpClient() }
     var basePath: String? = null
 
@@ -43,6 +46,11 @@ class Manager {
         }
     }
 
+    private val requestInterceptors: MutableList<((Request) -> Request) -> ((Request) -> Request)> =
+            mutableListOf()
+    private val responseInterceptors: MutableList<((Request, Response) -> Response) -> ((Request, Response) -> Response)> =
+            mutableListOf(redirectResponseInterceptor(), validatorResponseInterceptor(200..299))
+
     fun createExecutor() = if (Fuel.testConfiguration.blocking) SameThreadExecutorService() else executor
 
     //callback executor
@@ -61,6 +69,8 @@ class Manager {
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
         request.callbackExecutor = callbackExecutor
+        request.requestInterceptor = requestInterceptors.foldRight({ r: Request -> r }) { f, acc -> f(acc) }
+        request.responseInterceptor = responseInterceptors.foldRight({ req: Request, res: Response -> res }) { f, acc -> f(acc) }
         return request
     }
 
@@ -77,6 +87,8 @@ class Manager {
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
         request.callbackExecutor = callbackExecutor
+        request.requestInterceptor = requestInterceptors.foldRight({ r: Request -> r }) { f, acc -> f(acc) }
+        request.responseInterceptor = responseInterceptors.foldRight({ req: Request, res: Response -> res }) { f, acc -> f(acc) }
         return request
     }
 
@@ -94,6 +106,8 @@ class Manager {
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
         request.callbackExecutor = callbackExecutor
+        request.requestInterceptor = requestInterceptors.foldRight({ r: Request -> r }) { f, acc -> f(acc) }
+        request.responseInterceptor = responseInterceptors.foldRight({ req: Request, res: Response -> res }) { f, acc -> f(acc) }
         return request
     }
 
@@ -111,6 +125,8 @@ class Manager {
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
         request.callbackExecutor = callbackExecutor
+        request.requestInterceptor = requestInterceptors.foldRight({ r: Request -> r }) { f, acc -> f(acc) }
+        request.responseInterceptor = responseInterceptors.foldRight({ req: Request, res: Response -> res }) { f, acc -> f(acc) }
         return request
     }
 
@@ -128,6 +144,8 @@ class Manager {
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
         request.callbackExecutor = callbackExecutor
+        request.requestInterceptor = requestInterceptors.foldRight({ r: Request -> r }) { f, acc -> f(acc) }
+        request.responseInterceptor = responseInterceptors.foldRight({ req: Request, res: Response -> res }) { f, acc -> f(acc) }
         return request
     }
 
@@ -145,6 +163,8 @@ class Manager {
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
         request.callbackExecutor = callbackExecutor
+        request.requestInterceptor = requestInterceptors.foldRight({ r: Request -> r }) { f, acc -> f(acc) }
+        request.responseInterceptor = responseInterceptors.foldRight({ req: Request, res: Response -> res }) { f, acc -> f(acc) }
         return request
     }
 
@@ -155,7 +175,33 @@ class Manager {
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
         request.callbackExecutor = callbackExecutor
+        request.requestInterceptor = requestInterceptors.foldRight({ r: Request -> r }) { f, acc -> f(acc) }
+        request.responseInterceptor = responseInterceptors.foldRight({ req: Request, res: Response -> res }) { f, acc -> f(acc) }
         return request
+    }
+
+    fun addRequestInterceptor(interceptor: ((Request) -> Request) -> ((Request) -> Request)) {
+        requestInterceptors += interceptor
+    }
+
+    fun addResponseInterceptor(interceptor: ((Request, Response) -> Response) -> ((Request, Response) -> Response)) {
+        responseInterceptors += interceptor
+    }
+
+    fun removeRequestInterceptor(interceptor: ((Request) -> Request) -> ((Request) -> Request)) {
+        requestInterceptors -= interceptor
+    }
+
+    fun removeResponseInterceptor(interceptor: ((Request, Response) -> Response) -> ((Request, Response) -> Response)) {
+        responseInterceptors -= interceptor
+    }
+
+    fun removeAllRequestInterceptors() {
+        requestInterceptors.clear()
+    }
+
+    fun removeAllResponseInterceptors() {
+        responseInterceptors.clear()
     }
 
     companion object {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/LoggingInterceptors.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/LoggingInterceptors.kt
@@ -1,0 +1,19 @@
+package com.github.kittinunf.fuel.core.interceptors
+
+import com.github.kittinunf.fuel.core.Request
+
+fun <T> loggingInterceptor() =
+        { next: (T) -> T ->
+            { t: T ->
+                println(t.toString())
+                next(t)
+            }
+        }
+
+fun cUrlLoggingRequestInterceptor() =
+        { next: (Request) -> Request ->
+            { r: Request ->
+                println(r.cUrlString())
+                next(r)
+            }
+        }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -1,0 +1,39 @@
+package com.github.kittinunf.fuel.core.interceptors
+
+import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.Encoding
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
+import javax.net.ssl.HttpsURLConnection
+
+class RedirectException() : Exception("Redirection fail, not found URL to redirect to")
+
+fun redirectResponseInterceptor() =
+        { next: (Request, Response) -> Response ->
+            { request: Request, response: Response ->
+                if (response.httpStatusCode == HttpsURLConnection.HTTP_MOVED_PERM ||
+                        response.httpStatusCode == HttpsURLConnection.HTTP_MOVED_TEMP) {
+                    val redirectedUrl = response.httpResponseHeaders["Location"]
+                    if (redirectedUrl != null && !redirectedUrl.isEmpty()) {
+                        val encoding = Encoding().apply {
+                            httpMethod = request.httpMethod
+                            urlString = redirectedUrl[0]
+                        }
+                        Fuel.request(encoding).response().second
+                    } else {
+                        //error
+                        val error = FuelError().apply {
+                            exception = RedirectException()
+                            errorData = response.data
+                            this.response = response
+                        }
+                        throw error
+                    }
+                } else {
+                    next(request, response)
+                }
+            }
+        }
+
+ 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/ValidatorInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/ValidatorInterceptor.kt
@@ -1,0 +1,23 @@
+package com.github.kittinunf.fuel.core.interceptors
+
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.HttpException
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
+
+fun validatorResponseInterceptor(validRange: IntRange) =
+        { next: (Request, Response) -> Response ->
+            { request: Request, response: Response ->
+                if (!validRange.contains(response.httpStatusCode)) {
+                    val error = FuelError().apply {
+                        exception = HttpException(response.httpStatusCode, response.httpResponseMessage)
+                        errorData = response.data
+                        this.response = response
+                    }
+                    throw error
+                } else {
+                    next(request, response)
+                }
+            }
+        }
+

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/AsyncTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/AsyncTaskRequest.kt
@@ -4,6 +4,7 @@ import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Response
 
 class AsyncTaskRequest(val task: TaskRequest) : TaskRequest(task.request) {
+
     var successCallback: ((Response) -> Unit)? = null
     var failureCallback: ((FuelError, Response) -> Unit)? = null
 
@@ -24,4 +25,5 @@ class AsyncTaskRequest(val task: TaskRequest) : TaskRequest(task.request) {
         // FIXME
         return Response()
     }
+
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
@@ -10,6 +10,7 @@ import java.io.InputStream
 import java.net.URL
 
 class DownloadTaskRequest(request: Request) : TaskRequest(request) {
+
     val BUFFER_SIZE = 1024
 
     var progressCallback: ((Long, Long) -> Unit)? = null
@@ -29,4 +30,5 @@ class DownloadTaskRequest(request: Request) : TaskRequest(request) {
         }
         return response
     }
+
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/TaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/TaskRequest.kt
@@ -1,18 +1,22 @@
 package com.github.kittinunf.fuel.core.requests
 
-import com.github.kittinunf.fuel.core.*
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Manager
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
 import java.io.InterruptedIOException
 import java.util.concurrent.Callable
 
 open class TaskRequest(val request: Request) : Callable<Response> {
-    var validator: (Response) -> Boolean = { response ->
-        (200..299).contains(response.httpStatusCode)
-    }
+
     var interruptCallback: ((Request) -> Unit)? = null
 
     override fun call(): Response {
         try {
-            return Manager.instance.client.executeRequest(request).apply { validate(this) }
+            val modifiedRequest = request.requestInterceptor?.invoke(request) ?: request
+            val response = Manager.instance.client.executeRequest(modifiedRequest)
+            val modifiedResponse = request.responseInterceptor?.invoke(modifiedRequest, response) ?: response
+            return modifiedResponse
         } catch(error: FuelError) {
             if (error.exception as? InterruptedIOException != null) {
                 interruptCallback?.invoke(request)
@@ -21,15 +25,4 @@ open class TaskRequest(val request: Request) : Callable<Response> {
         }
     }
 
-    fun validate(response: Response) {
-        //validate
-        if (!validator(response)) {
-            val error = FuelError().apply {
-                exception = HttpException(response.httpStatusCode, response.httpResponseMessage)
-                errorData = response.data
-                this.response = response
-            }
-            throw error
-        }
-    }
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
@@ -1,0 +1,222 @@
+package com.github.kittinunf.fuel
+
+import com.github.kittinunf.fuel.core.Manager
+import com.github.kittinunf.fuel.core.Method
+import com.github.kittinunf.fuel.core.interceptors.cUrlLoggingRequestInterceptor
+import com.github.kittinunf.fuel.core.interceptors.loggingInterceptor
+import com.github.kittinunf.fuel.core.interceptors.redirectResponseInterceptor
+import com.github.kittinunf.fuel.core.interceptors.validatorResponseInterceptor
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.CoreMatchers.nullValue
+import org.junit.Assert.assertThat
+import org.junit.Test
+import java.net.HttpURLConnection
+import org.hamcrest.CoreMatchers.`is` as isEqualTo
+
+class InterceptorTest : BaseTestCase() {
+
+    @Test
+    fun testWithNoInterceptor() {
+        val manager = Manager()
+        val (request, response, result) = manager.request(Method.GET, "https://httpbin.org/get").response()
+        val (data, error) = result
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+    }
+
+    @Test
+    fun testWithLoggingInterceptor() {
+        val manager = Manager()
+        manager.addRequestInterceptor(loggingInterceptor())
+
+        val (request, response, result) = manager.request(Method.GET, "https://httpbin.org/get").response()
+        val (data, error) = result
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+    }
+
+    @Test
+    fun testWithMultipleInterceptors() {
+        val manager = Manager()
+
+        var interceptorCalled = false
+
+        fun <T> customLoggingInterceptor() = { next: (T) -> T ->
+            { t: T ->
+                println("1: ${t.toString()}")
+                interceptorCalled = true
+                next(t)
+            }
+        }
+
+        manager.apply {
+            addRequestInterceptor(cUrlLoggingRequestInterceptor())
+            addRequestInterceptor(customLoggingInterceptor())
+        }
+
+        val (request, response, result) = manager.request(Method.GET, "https://httpbin.org/get").header(mapOf("User-Agent" to "Fuel")).response()
+        val (data, error) = result
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(interceptorCalled, isEqualTo(true))
+    }
+
+    @Test
+    fun testWithBreakingChainInterceptor() {
+        val manager = Manager()
+
+        var interceptorCalled = false
+        fun <T> customLoggingBreakingInterceptor() = { next: (T) -> T ->
+            { t: T ->
+                println("1: ${t.toString()}")
+                interceptorCalled = true
+                //if next is not called, next Interceptor will not be called as well
+                t
+            }
+        }
+
+        var interceptorNotCalled = true
+        fun <T> customLoggingInterceptor() = { next: (T) -> T ->
+            { t: T ->
+                println("1: ${t.toString()}")
+                interceptorNotCalled = false
+                next(t)
+            }
+        }
+
+        manager.apply {
+            addRequestInterceptor(cUrlLoggingRequestInterceptor())
+            addRequestInterceptor(customLoggingBreakingInterceptor())
+            addRequestInterceptor(customLoggingInterceptor())
+        }
+
+        val (request, response, result) = manager.request(Method.GET, "https://httpbin.org/get").header(mapOf("User-Agent" to "Fuel")).response()
+        val (data, error) = result
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(interceptorCalled, isEqualTo(true))
+        assertThat(interceptorNotCalled, isEqualTo(true))
+    }
+
+    @Test
+    fun testWithRedirectInterceptor() {
+        val manager = Manager();
+
+        manager.addResponseInterceptor(redirectResponseInterceptor())
+        manager.addRequestInterceptor(cUrlLoggingRequestInterceptor())
+
+        val (request, response, result) = manager.request(Method.GET,
+                "https://httpbin.org/redirect-to",
+                listOf("url" to "http://jsonplaceholder.typicode.com/users"))
+                .header(mapOf("User-Agent" to "Fuel"))
+                .response()
+
+        val (data, error) = result
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+    }
+
+    @Test
+    fun testWithRedirectInterceptorRelative() {
+        val manager = Manager();
+
+        manager.addResponseInterceptor(redirectResponseInterceptor())
+        manager.addRequestInterceptor(cUrlLoggingRequestInterceptor())
+
+        val (request, response, result) = manager.request(Method.GET,
+                "https://httpbin.org/relative-redirect/3")
+                .header(mapOf("User-Agent" to "Fuel"))
+                .response()
+
+        val (data, error) = result
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+    }
+
+    @Test
+    fun testNestedRedirectWithRedirectInterceptor() {
+        val manager = Manager();
+
+        manager.addResponseInterceptor(redirectResponseInterceptor())
+        manager.addRequestInterceptor(cUrlLoggingRequestInterceptor())
+
+        val (request, response, result) = manager.request(Method.GET,
+                "https://httpbin.org/redirect-to",
+                listOf("url" to "https://httpbin.org/redirect-to?url=http://jsonplaceholder.typicode.com/users"))
+                .header(mapOf("User-Agent" to "Fuel"))
+                .response()
+
+        val (data, error) = result
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+    }
+
+    @Test
+    fun testHttpExceptionWithValidatorInterceptor() {
+        val manager = Manager();
+        manager.addResponseInterceptor(validatorResponseInterceptor(200..299))
+        manager.addRequestInterceptor(cUrlLoggingRequestInterceptor())
+
+        val (request, response, result) = manager.request(Method.GET,
+                "http://httpbin.org/status/418").response()
+
+        val (data, error) = result
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, notNullValue())
+        assertThat(data, nullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(418))
+    }
+
+    @Test
+    fun testHttpExceptionWithRemoveInterceptors() {
+        val manager = Manager();
+        manager.removeAllResponseInterceptors()
+
+        val (request, response, result) = manager.request(Method.GET,
+                "http://httpbin.org/status/418").response()
+
+        val (data, error) = result
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(418))
+    }
+
+}
+ 

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestValidationTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestValidationTest.kt
@@ -1,6 +1,7 @@
 package com.github.kittinunf.fuel
 
 import com.github.kittinunf.fuel.core.*
+import com.github.kittinunf.fuel.core.interceptors.validatorResponseInterceptor
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.getAs
 import org.hamcrest.CoreMatchers.notNullValue
@@ -54,8 +55,11 @@ class RequestValidationTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
+        manager.removeAllResponseInterceptors()
+        manager.addResponseInterceptor(validatorResponseInterceptor(200..202))
+
         //this validate (200..202) which should fail with 203
-        manager.request(Method.GET, "/status/$preDefinedStatusCode").validate(200..202).responseString { req, res, result ->
+        manager.request(Method.GET, "/status/$preDefinedStatusCode").responseString { req, res, result ->
             request = req
             response = res
 
@@ -81,7 +85,10 @@ class RequestValidationTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
-        manager.request(Method.GET, "/status/$preDefinedStatusCode").validate(400..419).response { req, res, result ->
+        manager.removeAllResponseInterceptors()
+        manager.addResponseInterceptor(validatorResponseInterceptor(400..419))
+
+        manager.request(Method.GET, "/status/$preDefinedStatusCode").response { req, res, result ->
             request = req
             response = res
 


### PR DESCRIPTION
Introducing Interceptor's concept into Fuel. There are two types of interceptors which are `RequestInterceptor` and `ResponseInterceptor`. 

`RequestInterceptor` is in type of `(Request) -> Request) -> ((Request) -> Request)`.

Simple usage of RequestInterceptor is `cUrlLoggingInterceptor` can be simply implemented as such

``` Kotlin
fun cUrlLoggingRequestInterceptor() =
        { next: (Request) -> Request ->
            { r: Request ->
                println(r.cUrlString())
                next(r)
            }
        }
```

And usage will be 

``` Kotlin
//Initialization phase
manager.addRequestInterceptor(cUrlLoggingInterceptor())

manager.request(Method.GET, "https://httpbin.org/get").header("User-Agent", "Fuel").response()

// print
curl -i -H "User-Agent:Fuel" "https://httpbin.org/get"
```

`next` is a way to let user customize the behavior of interceptor even more. Without calling `next`, next interceptor chain will not be called.

For `ResponseInterceptor`, it is in type of `(Request, Response) -> Response -> (Request, Response) -> Response`. This makes Redirection to be supported with one type of ResponseInterceptor by checking whether Response type is either `301` or `302`. Then, re-request with new URL in location header.