### PR TITLE
Add responseJson in sync mode in Android module, fix #71

### DIFF
--- a/fuel-android/src/main/kotlin/com/github/kittinunf/fuel/android/extension/Requests.kt
+++ b/fuel-android/src/main/kotlin/com/github/kittinunf/fuel/android/extension/Requests.kt
@@ -10,6 +10,8 @@ fun Request.responseJson(handler: (Request, Response, Result<JSONObject, FuelErr
 
 fun Request.responseJson(handler: Handler<JSONObject>) = response(jsonDeserializer(), handler)
 
+fun Request.responseJson() = response(jsonDeserializer())
+
 fun jsonDeserializer(): Deserializable<JSONObject> {
     return object : Deserializable<JSONObject> {
         override fun deserialize(response: Response): JSONObject {

--- a/fuel-android/src/test/kotlin/com/github/kittinunf/fuel/android/RequestAndroidSyncTest.kt
+++ b/fuel-android/src/test/kotlin/com/github/kittinunf/fuel/android/RequestAndroidSyncTest.kt
@@ -1,0 +1,35 @@
+package com.github.kittinunf.fuel.android
+
+import com.github.kittinunf.fuel.android.extension.responseJson
+import com.github.kittinunf.fuel.core.Manager
+import com.github.kittinunf.fuel.httpGet
+import org.hamcrest.CoreMatchers.*
+import org.json.JSONObject
+import org.junit.Assert.assertThat
+import org.junit.Test
+import java.net.HttpURLConnection
+import org.hamcrest.CoreMatchers.`is` as isEqualTo
+
+class RequestAndroidSyncTest : BaseTestCase() {
+
+    init {
+        Manager.instance.basePath = "https://httpbin.org"
+        Manager.instance.baseHeaders = mapOf("foo" to "bar")
+        Manager.instance.baseParams = listOf("key" to "value")
+    }
+
+    @Test
+    fun httpSyncRequestTest() {
+        val (request, response, result) = "/get".httpGet(listOf("hello" to "world")).responseJson()
+        val (data, error) = result
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+        assertThat(data as JSONObject, isA(JSONObject::class.java))
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+    }
+
+}


### PR DESCRIPTION
Just a single line to support `responseJson()`.