### PR TITLE
Redirection following can now be disabled for relative urls. With test.

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
@@ -48,7 +48,7 @@ class FuelManager {
     private val requestInterceptors: MutableList<((Request) -> Request) -> ((Request) -> Request)> =
             mutableListOf()
     private val responseInterceptors: MutableList<((Request, Response) -> Response) -> ((Request, Response) -> Response)> =
-            mutableListOf(redirectResponseInterceptor(), validatorResponseInterceptor(200..299))
+            mutableListOf(redirectResponseInterceptor(this), validatorResponseInterceptor(200..299))
 
     fun createExecutor() = if (Fuel.testConfiguration.blocking) SameThreadExecutorService() else executor
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -5,6 +5,8 @@ import com.github.kittinunf.fuel.core.Encoding
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
+import java.net.MalformedURLException
+import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 
 class RedirectException() : Exception("Redirection fail, not found URL to redirect to")
@@ -18,7 +20,13 @@ fun redirectResponseInterceptor() =
                     if (redirectedUrl != null && !redirectedUrl.isEmpty()) {
                         val encoding = Encoding().apply {
                             httpMethod = request.httpMethod
-                            urlString = redirectedUrl[0]
+                            urlString = try {
+                                URL(redirectedUrl[0]).toString()
+                            } catch (e: MalformedURLException){
+                                // Maybe its a relative url
+                                val serverPart = request.url.protocol + "://" + request.url.authority
+                                URL(serverPart + redirectedUrl[0]).toString()
+                            }
                         }
                         Fuel.request(encoding).response().second
                     } else {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -20,12 +20,12 @@ fun redirectResponseInterceptor() =
                     if (redirectedUrl != null && !redirectedUrl.isEmpty()) {
                         val encoding = Encoding().apply {
                             httpMethod = request.httpMethod
-                            urlString = try {
+                            urlString =
+                            try {
                                 URL(redirectedUrl[0]).toString()
                             } catch (e: MalformedURLException){
-                                // Maybe its a relative url
-                                val serverPart = request.url.protocol + "://" + request.url.authority
-                                URL(serverPart + redirectedUrl[0]).toString()
+                                // Maybe its a relative url. Use the original for context.
+                                URL(request.url, redirectedUrl[0]).toString()
                             }
                         }
                         Fuel.request(encoding).response().second

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -1,17 +1,13 @@
 package com.github.kittinunf.fuel.core.interceptors
 
-import com.github.kittinunf.fuel.Fuel
-import com.github.kittinunf.fuel.core.Encoding
-import com.github.kittinunf.fuel.core.FuelError
-import com.github.kittinunf.fuel.core.Request
-import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.fuel.core.*
 import java.net.MalformedURLException
 import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 
 class RedirectException() : Exception("Redirection fail, not found URL to redirect to")
 
-fun redirectResponseInterceptor() =
+fun redirectResponseInterceptor(manager: FuelManager) =
         { next: (Request, Response) -> Response ->
             { request: Request, response: Response ->
                 if (response.httpStatusCode == HttpsURLConnection.HTTP_MOVED_PERM ||
@@ -28,7 +24,7 @@ fun redirectResponseInterceptor() =
                                 URL(request.url, redirectedUrl[0]).toString()
                             }
                         }
-                        Fuel.request(encoding).response().second
+                        manager.request(encoding).response().second
                     } else {
                         //error
                         val error = FuelError().apply {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -26,6 +26,7 @@ class HttpClient : Client {
                 useCaches = false
                 requestMethod = request.httpMethod.value
                 setDoOutput(connection, request.httpMethod)
+                instanceFollowRedirects = false
                 for ((key, value) in request.httpHeaders) {
                     setRequestProperty(key, value)
                 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
@@ -5,8 +5,7 @@ import com.github.kittinunf.fuel.core.Method
 import com.github.kittinunf.fuel.core.interceptors.cUrlLoggingRequestInterceptor
 import com.github.kittinunf.fuel.core.interceptors.loggingInterceptor
 import com.github.kittinunf.fuel.core.interceptors.validatorResponseInterceptor
-import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.CoreMatchers.*
 import org.junit.Assert.assertThat
 import org.junit.Test
 import java.net.HttpURLConnection
@@ -174,6 +173,25 @@ class InterceptorTest : BaseTestCase() {
         assertThat(response, notNullValue())
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+    }
+
+    @Test
+    fun testWithRedirectInterceptorPreservesBaseHeaders() {
+        val manager = FuelManager()
+        manager.addRequestInterceptor(cUrlLoggingRequestInterceptor())
+
+        manager.baseHeaders = mapOf("User-Agent" to "Fuel")
+        val (request, response, result) = manager.request(Method.GET,
+                "https://httpbin.org/redirect-to?url=/user-agent")
+                .responseString(Charsets.UTF_8)
+
+        val (data, error) = result
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, containsString("\"user-agent\": \"Fuel\""))
 
         assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
@@ -141,6 +141,26 @@ class InterceptorTest : BaseTestCase() {
     }
 
     @Test
+    fun testWithoutDefaultRedirectionInterceptor(){
+        val manager = FuelManager()
+        manager.addRequestInterceptor(cUrlLoggingRequestInterceptor())
+        manager.removeAllResponseInterceptors()
+
+        val (request, response, result) = manager.request(Method.GET,
+                "https://httpbin.org/relative-redirect/3")
+                .header(mapOf("User-Agent" to "Fuel"))
+                .response()
+
+        val (data, error) = result
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_MOVED_TEMP))
+    }
+
+    @Test
     fun testWithRedirectInterceptorRelative() {
         val manager = FuelManager();
 

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
@@ -4,7 +4,6 @@ import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.Method
 import com.github.kittinunf.fuel.core.interceptors.cUrlLoggingRequestInterceptor
 import com.github.kittinunf.fuel.core.interceptors.loggingInterceptor
-import com.github.kittinunf.fuel.core.interceptors.redirectResponseInterceptor
 import com.github.kittinunf.fuel.core.interceptors.validatorResponseInterceptor
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.CoreMatchers.nullValue
@@ -122,7 +121,6 @@ class InterceptorTest : BaseTestCase() {
     fun testWithRedirectInterceptor() {
         val manager = FuelManager();
 
-        manager.addResponseInterceptor(redirectResponseInterceptor())
         manager.addRequestInterceptor(cUrlLoggingRequestInterceptor())
 
         val (request, response, result) = manager.request(Method.GET,
@@ -164,7 +162,6 @@ class InterceptorTest : BaseTestCase() {
     fun testWithRedirectInterceptorRelative() {
         val manager = FuelManager();
 
-        manager.addResponseInterceptor(redirectResponseInterceptor())
         manager.addRequestInterceptor(cUrlLoggingRequestInterceptor())
 
         val (request, response, result) = manager.request(Method.GET,
@@ -185,7 +182,6 @@ class InterceptorTest : BaseTestCase() {
     fun testNestedRedirectWithRedirectInterceptor() {
         val manager = FuelManager();
 
-        manager.addResponseInterceptor(redirectResponseInterceptor())
         manager.addRequestInterceptor(cUrlLoggingRequestInterceptor())
 
         val (request, response, result) = manager.request(Method.GET,


### PR DESCRIPTION
HTTPUrlConnection is following redirects by default. It seems the idea is that this is to be handled by Fuel itself.

I couldnt run the other tests as typicode.com returns 403 for me, but the new test case failed before and doesnt now.