### PR TITLE
fix upload task

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -14,7 +14,7 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
 
     val BUFFER_SIZE = 1024
 
-    val CRLF = "\\r\\n"
+    val CRLF = "\r\n"
     /*val boundary = System.currentTimeMillis().toHexString()*/
     val boundary = request.httpHeaders["Content-Type"]!!.split("=", limit=2)[1]
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -15,7 +15,6 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
     val BUFFER_SIZE = 1024
 
     val CRLF = "\r\n"
-    /*val boundary = System.currentTimeMillis().toHexString()*/
     val boundary = request.httpHeaders["Content-Type"]!!.split("=", limit=2)[1]
 
     var progressCallback: ((Long, Long) -> Unit)? = null

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -15,7 +15,8 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
     val BUFFER_SIZE = 1024
 
     val CRLF = "\\r\\n"
-    val boundary = System.currentTimeMillis().toHexString()
+    /*val boundary = System.currentTimeMillis().toHexString()*/
+    val boundary = request.httpHeaders["Content-Type"]!!.split("=", limit=2)[1]
 
     var progressCallback: ((Long, Long) -> Unit)? = null
     lateinit var sourceCallback: ((Request, URL) -> File)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -15,7 +15,7 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
     val BUFFER_SIZE = 1024
 
     val CRLF = "\r\n"
-    val boundary = request.httpHeaders["Content-Type"]!!.split("=", limit=2)[1]
+    val boundary = request.httpHeaders["Content-Type"]?.split("=", limit=2)?.get(1) ?: System.currentTimeMillis().toHexString()
 
     var progressCallback: ((Long, Long) -> Unit)? = null
     lateinit var sourceCallback: ((Request, URL) -> File)


### PR DESCRIPTION
The current code has following problem:
1. the boundary in the content-type and that in body may be different. See #113 .
2. the CRLF is escaped that CRLF in packet is \x5c \x72 \x5c \x6e instead of \x0d \x0a .

This PR fixes above problems and makes upload works correctly.
