### PR TITLE
Use AssertableSubscriber instead of subscribing to the Observable

### DIFF
--- a/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
+++ b/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
@@ -1,17 +1,17 @@
 package com.github.kittinunf.fuel
 
 import com.github.kittinunf.fuel.core.FuelManager
-import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.ResponseDeserializable
 import com.github.kittinunf.fuel.rx.rx_response
 import com.github.kittinunf.fuel.rx.rx_responseObject
 import com.github.kittinunf.fuel.rx.rx_responseString
 import com.github.kittinunf.fuel.rx.rx_string
 import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.CoreMatchers.nullValue
 import org.junit.Assert.assertThat
 import org.junit.Test
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
+
+
 
 class RxFuelTest {
 
@@ -25,17 +25,14 @@ class RxFuelTest {
 
     @Test
     fun rxTestResponse() {
-        var called = false
-        var response: Response? = null
-        var data: ByteArray? = null
-        Fuel.get("/get").rx_response().subscribe {
-            val (r, d) = it
-            response = r
-            data = d
-            called = true
-        }
+        val (response, data) = Fuel.get("/get").rx_response()
+                .test()
+                .awaitTerminalEvent()
+                .assertNoErrors()
+                .assertValueCount(1)
+                .assertCompleted()
+                .onNextEvents[0]
 
-        assertThat(called, isEqualTo(true))
         assertThat(response, notNullValue())
         assertThat(data, notNullValue())
     }
@@ -43,49 +40,39 @@ class RxFuelTest {
 
     @Test
     fun rxTestResponseString() {
-        var called = false
-        var response: Response? = null
-        var data: String? = null
-        Fuel.get("/get").rx_responseString().subscribe {
-            val (r, d) = it
-            response = r
-            data = d
-            called = true
-        }
+        val (response, data) = Fuel.get("/get").rx_responseString()
+                .test()
+                .awaitTerminalEvent()
+                .assertNoErrors()
+                .assertValueCount(1)
+                .assertCompleted()
+                .onNextEvents[0]
 
-        assertThat(called, isEqualTo(true))
         assertThat(response, notNullValue())
         assertThat(data, notNullValue())
     }
 
     @Test
     fun rxTestString() {
-        var called = false
-        var data: String? = null
-        Fuel.get("/get").rx_string().subscribe {
-            data = it
-            called = true
-        }
+        val data = Fuel.get("/get").rx_string()
+                .test()
+                .awaitTerminalEvent()
+                .assertNoErrors()
+                .assertValueCount(1)
+                .assertCompleted()
+                .onNextEvents[0]
 
-        assertThat(called, isEqualTo(true))
         assertThat(data, notNullValue())
     }
 
     @Test
     fun rxTestStringError() {
-        var calledError = false
-        var data: String? = null
-        var error: Throwable? = null
-        Fuel.get("/gt").rx_string().subscribe({
-            data = it
-        }, { ex ->
-            error = ex
-            calledError = true
-        })
-
-        assertThat(calledError, isEqualTo(true))
-        assertThat(data, nullValue())
-        assertThat(error, notNullValue())
+        Fuel.get("/gt").rx_string()
+                .test()
+                .awaitTerminalEvent()
+                .assertNoValues()
+                .assertError(Throwable::class.java)
+                .assertNotCompleted()
     }
 
     //Model
@@ -102,40 +89,27 @@ class RxFuelTest {
 
     @Test
     fun rxTestResponseObject() {
-        var called = false
-        var response: Response? = null
-        var model: HttpBinUserAgentModel? = null
-        Fuel.get("/user-agent").rx_responseObject(HttpBinUserAgentModelDeserializer()).subscribe {
-            val (r, d) = it
-            response = r
-            model = d
-            called = true
-        }
+        val (response, model) = Fuel.get("/user-agent")
+                .rx_responseObject(HttpBinUserAgentModelDeserializer())
+                .test()
+                .awaitTerminalEvent()
+                .assertNoErrors()
+                .assertValueCount(1)
+                .assertCompleted()
+                .onNextEvents[0]
 
-        assertThat(called, isEqualTo(true))
         assertThat(response, notNullValue())
         assertThat(model, notNullValue())
     }
 
     @Test
     fun rxTestResponseObjectError() {
-        var calledError = false
-        var response: Response? = null
-        var model: HttpBinUserAgentModel? = null
-        var error: Throwable? = null
-        Fuel.get("/useragent").rx_responseObject(HttpBinUserAgentModelDeserializer()).subscribe({
-            val (r, d) = it
-            response = r
-            model = d
-        }, { ex ->
-            calledError = true
-            error = ex
-        })
-
-        assertThat(calledError, isEqualTo(true))
-        assertThat(response, nullValue())
-        assertThat(model, nullValue())
-        assertThat(error, notNullValue())
+        Fuel.get("/useragent").rx_responseObject(HttpBinUserAgentModelDeserializer())
+                .test()
+                .awaitTerminalEvent()
+                .assertNoValues()
+                .assertError(Throwable::class.java)
+                .assertNotCompleted()
     }
 
 

--- a/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
+++ b/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
@@ -11,8 +11,6 @@ import org.junit.Assert.assertThat
 import org.junit.Test
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
-
-
 class RxFuelTest {
 
     init {


### PR DESCRIPTION
Hi @kittinunf :)

I've modified RxFuelTest class in order to take advantage of the built-in support that RxJava offers to testing in a more "reactive" idiomatic way.  

