### PR TITLE
FuelError.toString provides more useful information

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
@@ -7,5 +7,5 @@ class FuelError : Exception() {
     var errorData = ByteArray(0)
     var response = Response()
 
-    override fun toString(): String = "Exception : ${exception.message}"
+    override fun toString(): String = "${exception.javaClass.canonicalName}: ${exception.message ?: "<no message>"}"
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/ErrorTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/ErrorTest.kt
@@ -1,0 +1,31 @@
+package com.github.kittinunf.fuel
+
+import com.github.kittinunf.fuel.core.FuelError
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+
+class ErrorTest: BaseTestCase() {
+    @Test
+    fun testNoMessageException() {
+        val error = FuelError().apply {
+            exception = RuntimeException()
+        }
+
+        assertThat(error.toString(), containsString("<no message>"))
+        assertThat(error.toString(), not(containsString("null")))
+        assertThat(error.toString(), containsString("RuntimeException"))
+    }
+
+    @Test
+    fun testMessageException() {
+        val error = FuelError().apply {
+            exception = RuntimeException("error")
+        }
+
+        assertThat(error.toString(), containsString("error"))
+        assertThat(error.toString(), not(containsString("<no message>")))
+    }
+}


### PR DESCRIPTION
I was chasing down a bug in an Android application that was resulting in a failure, but the exception that caused it didn't provide a `message`, so I was staring at a bunch of `Failure { Exception : null }` in my logcat, which wasn't very helpful.

This change causes `FuelError.toString` to provide the fully-qualified name of the causing exception and its message (if present), defaulting to `"<no message>"` otherwise (since reading `null` if you're not expecting an error message in the first place isn't very helpful).