### PR TITLE
Multiple files upload

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -131,7 +131,7 @@ class Request : Fuel.RequestConvertible {
         return this
     }
 
-    fun sources(source: (Request, URL) -> Collection<File>): Request {
+    fun sources(source: (Request, URL) -> Iterable<File>): Request {
         val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
 
         uploadTaskRequest.apply {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -131,7 +131,7 @@ class Request : Fuel.RequestConvertible {
         return this
     }
 
-    fun sources(source: (Request, URL) -> Array<File>): Request {
+    fun sources(source: (Request, URL) -> Collection<File>): Request {
         val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
 
         uploadTaskRequest.apply {
@@ -141,11 +141,10 @@ class Request : Fuel.RequestConvertible {
     }
 
     fun source(source: (Request, URL) -> File): Request {
-        val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
-
-        uploadTaskRequest.apply {
-            sourceCallback = { request, url -> arrayOf(source.invoke(request, request.url)) }
+        sources { request, url ->
+            listOf(source.invoke(request, request.url))
         }
+
         return this
     }
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -131,11 +131,20 @@ class Request : Fuel.RequestConvertible {
         return this
     }
 
-    fun source(source: (Request, URL) -> File): Request {
+    fun sources(source: (Request, URL) -> Array<File>): Request {
         val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
 
         uploadTaskRequest.apply {
             sourceCallback = source
+        }
+        return this
+    }
+
+    fun source(source: (Request, URL) -> File): Request {
+        val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
+
+        uploadTaskRequest.apply {
+            sourceCallback = { request, url -> arrayOf(source.invoke(request, request.url)) }
         }
         return this
     }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -31,7 +31,8 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
                 files.forEachIndexed { i, file ->
                     val postFix = if (files.size == 1) "" else "${i + 1}"
 
-                    write("--$boundary$CRLF")
+                    write("--$boundary")
+                    write(CRLF)
                     write("Content-Disposition: form-data; name=\"" + request.name + "$postFix\"; filename=\"${file.name}\"")
                     write(CRLF)
                     write("Content-Type: " + URLConnection.guessContentTypeFromName(file.name))
@@ -49,9 +50,12 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
                 }
 
                 request.parameters.forEach {
-                    write("--$boundary$CRLF")
-                    write("Content-Disposition: form-data; name=\"${it.first}\"$CRLF")
-                    write("Content-Type: text/plain$CRLF")
+                    write("--$boundary")
+                    write(CRLF)
+                    write("Content-Disposition: form-data; name=\"${it.first}\"")
+                    write(CRLF)
+                    write("Content-Type: text/plain")
+                    write(CRLF)
                     write(CRLF)
                     write(it.second.toString())
                     write(CRLF)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -19,7 +19,7 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
     val boundary = request.httpHeaders["Content-Type"]?.split("=", limit = 2)?.get(1) ?: System.currentTimeMillis().toHexString()
 
     var progressCallback: ((Long, Long) -> Unit)? = null
-    lateinit var sourceCallback: (Request, URL) -> Collection<File>
+    lateinit var sourceCallback: (Request, URL) -> Iterable<File>
 
     var dataStream: ByteArrayOutputStream? = null
 
@@ -29,7 +29,7 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
                 val files = sourceCallback.invoke(request, request.url)
 
                 files.forEachIndexed { i, file ->
-                    val postFix = if (files.size == 1) "" else "${i + 1}"
+                    val postFix = if (files.count() == 1) "" else "${i + 1}"
 
                     write("--$boundary")
                     write(CRLF)

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
@@ -201,4 +201,38 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(response?.httpStatusCode, isEqualTo(statusCode))
     }
 
+    @Test
+    fun httpUploadWithMultipleFiles() {
+        var request: Request? = null
+        var response: Response? = null
+        var data: Any? = null
+        var error: FuelError? = null
+
+        manager.upload("/post", param = listOf("foo" to "bar"))
+                .sources { request, url ->
+                    arrayOf(File(currentDir, "lorem_ipsum_short.tmp"),
+                            File(currentDir, "lorem_ipsum_long.tmp"))
+                }
+                .name { "file-name" }
+                .responseString { req, res, result ->
+                    request = req
+                    response = res
+                    val (d, err) = result
+                    data = d
+                    error = err
+                    print(d)
+                }
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        val string = data as String
+        assertThat(string, containsString("file-name1"))
+        assertThat(string, containsString("file-name2"))
+
+        val statusCode = HttpURLConnection.HTTP_OK
+        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+    }
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
@@ -23,7 +23,7 @@ class RequestUploadTest : BaseTestCase() {
 
     val currentDir: File by lazy {
         val dir = System.getProperty("user.dir")
-        File(dir, "src/test/assets")
+        File(dir, "fuel/src/test/assets")
     }
 
     @Test
@@ -210,7 +210,7 @@ class RequestUploadTest : BaseTestCase() {
 
         manager.upload("/post", param = listOf("foo" to "bar"))
                 .sources { request, url ->
-                    arrayOf(File(currentDir, "lorem_ipsum_short.tmp"),
+                    listOf(File(currentDir, "lorem_ipsum_short.tmp"),
                             File(currentDir, "lorem_ipsum_long.tmp"))
                 }
                 .name { "file-name" }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
@@ -23,7 +23,7 @@ class RequestUploadTest : BaseTestCase() {
 
     val currentDir: File by lazy {
         val dir = System.getProperty("user.dir")
-        File(dir, "fuel/src/test/assets")
+        File(dir, "src/test/assets")
     }
 
     @Test


### PR DESCRIPTION
### What's in this PR?

Implementation of multiple files upload as mentioned in #147 . I created new method call `sources` so we can pass multiple files into `sourceCallback`.

Example

```Kotlin
sources { request, url ->
   arrayOf(
      File(currentDir, "lorem_ipsum_short.tmp"),
      File(currentDir, "lorem_ipsum_long.tmp")
   )
}
```