### PR TITLE
Custom form data part

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
@@ -1,0 +1,8 @@
+package com.github.kittinunf.fuel.core
+
+import java.io.File
+
+data class DataPart(
+        var fileName: String = "",
+        var mediaType: String = "",
+        var file: File)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
@@ -3,6 +3,6 @@ package com.github.kittinunf.fuel.core
 import java.io.File
 
 data class DataPart(
-        var fileName: String = "",
-        var mediaType: String = "",
-        var file: File)
+        val fileName: String = "",
+        val mediaType: String = "",
+        val file: File)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
@@ -3,6 +3,6 @@ package com.github.kittinunf.fuel.core
 import java.io.File
 
 data class DataPart(
-        val fileName: String = "",
-        val mediaType: String = "",
-        val file: File)
+        val file: File,
+        val name: String = file.name.split(".").getOrElse(0) { "" },
+        val type: String = "")

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -45,8 +45,8 @@ class Request : Fuel.RequestConvertible {
 
     var name = ""
 
-    var names = mutableListOf<String>()
-    var mediaTypes = mutableListOf<String>()
+    val names = mutableListOf<String>()
+    val mediaTypes = mutableListOf<String>()
 
     //underlying task request
     val taskRequest: TaskRequest by lazy {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -134,23 +134,19 @@ class Request : Fuel.RequestConvertible {
         return this
     }
 
-    fun dataPart(dataPart: (Request, URL) -> DataPart): Request {
-        dataParts { request, url ->
-            listOf(dataPart.invoke(request, url))
-        }
-
-        return this
-    }
-
     fun dataParts(dataParts: (Request, URL) -> Iterable<DataPart>): Request {
         val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
         val parts = dataParts.invoke(request, request.url)
 
-        mediaTypes.clear()
-        mediaTypes.addAll(parts.map { it.type })
+        mediaTypes.apply {
+            clear()
+            addAll(parts.map { it.type })
+        }
 
-        names.clear()
-        names.addAll(parts.map { it.name })
+        names.apply {
+            clear()
+            addAll(parts.map { it.name })
+        }
 
         uploadTaskRequest.apply {
             sourceCallback = { request, url -> parts.map { it.file } }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -134,15 +134,23 @@ class Request : Fuel.RequestConvertible {
         return this
     }
 
+    fun dataPart(dataPart: (Request, URL) -> DataPart): Request {
+        dataParts { request, url ->
+            listOf(dataPart.invoke(request, url))
+        }
+
+        return this
+    }
+
     fun dataParts(dataParts: (Request, URL) -> Iterable<DataPart>): Request {
         val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
         val parts = dataParts.invoke(request, request.url)
 
         mediaTypes.clear()
-        mediaTypes.addAll(parts.map { it.mediaType })
+        mediaTypes.addAll(parts.map { it.type })
 
         names.clear()
-        names.addAll(parts.map { it.fileName })
+        names.addAll(parts.map { it.name })
 
         uploadTaskRequest.apply {
             sourceCallback = { request, url -> parts.map { it.file } }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -45,8 +45,8 @@ class Request : Fuel.RequestConvertible {
 
     var name = ""
 
-    var names = arrayListOf<String>()
-    var mediaTypes = arrayListOf<String>()
+    var names = mutableListOf<String>()
+    var mediaTypes = mutableListOf<String>()
 
     //underlying task request
     val taskRequest: TaskRequest by lazy {
@@ -135,6 +135,7 @@ class Request : Fuel.RequestConvertible {
     }
 
     fun dataParts(dataParts: (Request, URL) -> Iterable<DataPart>): Request {
+        val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
         val parts = dataParts.invoke(request, request.url)
 
         mediaTypes.clear()
@@ -143,12 +144,8 @@ class Request : Fuel.RequestConvertible {
         names.clear()
         names.addAll(parts.map { it.fileName })
 
-        val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
-
         uploadTaskRequest.apply {
-            sourceCallback = { request, url ->
-                parts.map { it.file }
-            }
+            sourceCallback = { request, url -> parts.map { it.file } }
         }
 
         return this

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -30,12 +30,13 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
 
                 files.forEachIndexed { i, file ->
                     val postFix = if (files.count() == 1) "" else "${i + 1}"
-
+                    val fileName = request.names.getOrElse(i) { request.name + postFix }
+                    
                     write("--$boundary")
                     write(CRLF)
-                    write("Content-Disposition: form-data; name=\"" + request.name + "$postFix\"; filename=\"${file.name}\"")
+                    write("Content-Disposition: form-data; name=\"$fileName\"; filename=\"${file.name}\"")
                     write(CRLF)
-                    write("Content-Type: " + URLConnection.guessContentTypeFromName(file.name))
+                    write("Content-Type: " + request.mediaTypes.getOrElse(i) { URLConnection.guessContentTypeFromName(file.name) ?: "" })
                     write(CRLF)
                     write(CRLF)
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -10,6 +10,7 @@ import java.io.FileInputStream
 import java.io.OutputStream
 import java.net.URL
 import java.net.URLConnection
+import javax.activation.MimetypesFileTypeMap
 
 class UploadTaskRequest(request: Request) : TaskRequest(request) {
 
@@ -31,12 +32,12 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
                 files.forEachIndexed { i, file ->
                     val postFix = if (files.count() == 1) "" else "${i + 1}"
                     val fileName = request.names.getOrElse(i) { request.name + postFix }
-                    
+
                     write("--$boundary")
                     write(CRLF)
                     write("Content-Disposition: form-data; name=\"$fileName\"; filename=\"${file.name}\"")
                     write(CRLF)
-                    write("Content-Type: " + request.mediaTypes.getOrElse(i) { URLConnection.guessContentTypeFromName(file.name) ?: "" })
+                    write("Content-Type: " + request.mediaTypes.getOrElse(i) { guessContentType(file) })
                     write(CRLF)
                     write(CRLF)
 
@@ -72,6 +73,10 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
         } finally {
             dataStream?.close()
         }
+    }
+
+    private fun guessContentType(file: File): String {
+        return URLConnection.guessContentTypeFromName(file.name) ?: MimetypesFileTypeMap().getContentType(file)
     }
 }
 

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
@@ -240,17 +240,10 @@ class RequestUploadTest : BaseTestCase() {
         var error: FuelError? = null
 
         manager.upload("/post", param = listOf("foo" to "bar"))
-                .sources { request, url ->
-                    listOf(File(currentDir, "lorem_ipsum_short.tmp"),
-                            File(currentDir, "lorem_ipsum_long.tmp"))
-                }
-                // Override with Data parts
                 .dataParts { request, url ->
                     listOf(DataPart("first-file", "image/jpeg", File(currentDir, "lorem_ipsum_short.tmp")),
                             DataPart("second-file", "image/jpeg", File(currentDir, "lorem_ipsum_long.tmp")))
                 }
-                // Ignore single name
-                .name { "filename" }
                 .responseString { req, res, result ->
                     request = req
                     response = res

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
@@ -254,7 +254,6 @@ class RequestUploadTest : BaseTestCase() {
                 .responseString { req, res, result ->
                     request = req
                     response = res
-                    print(req)
                     val (d, err) = result
                     data = d
                     error = err

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
@@ -233,38 +233,6 @@ class RequestUploadTest : BaseTestCase() {
     }
 
     @Test
-    fun httpUploadWithDataPart() {
-        var request: Request? = null
-        var response: Response? = null
-        var data: Any? = null
-        var error: FuelError? = null
-
-        manager.upload("/post", param = listOf("foo" to "bar"))
-                .dataPart { request, url ->
-                    DataPart(File(currentDir, "lorem_ipsum_short.tmp"), type = "image/jpeg")
-                }
-                .responseString { req, res, result ->
-                    request = req
-                    response = res
-                    val (d, err) = result
-                    data = d
-                    error = err
-                    print(d)
-                }
-
-        assertThat(request, notNullValue())
-        assertThat(response, notNullValue())
-        assertThat(error, nullValue())
-        assertThat(data, notNullValue())
-
-        val string = data as String
-        assertThat(string, containsString("lorem_ipsum_short"))
-
-        val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
-    }
-
-    @Test
     fun httpUploadWithMultipleDataParts() {
         var request: Request? = null
         var response: Response? = null


### PR DESCRIPTION
### What's in this PR?

Let user input specific file's name and content type using `DataPart`

Example

```Kotlin
.upload("/post")
.dataParts { request, url ->
   listOf(
      DataPart(File(currentDir, "lorem_ipsum_short.tmp"), "image/jpeg"),
      DataPart(File(currentDir, "lorem_ipsum_long.tmp"), "second-file", "image/jpeg")
   )
}
.responseString { req, res, result -> }
```

And also avoid `null` content type by using `MimetypesFileTypeMap`

Merging this should close #155 and #161 