### PR TITLE
Stop trying to read http head response input streams.

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -57,10 +57,13 @@ class HttpClient(val proxy: Proxy? = null) : Client {
                 }
 
                 if (dataStream != null) {
-                    data = if (contentEncoding.compareTo("gzip", true) == 0) {
-                        GZIPInputStream(dataStream).readBytes()
-                    } else {
-                        dataStream.readBytes()
+                    // HEAD responses have no input stream. Trying to parse an empty GZIPInputStream fails.
+                    data = if (request.httpMethod == Method.HEAD) ByteArray(0) else {
+                        if (contentEncoding.compareTo("gzip", true) == 0) {
+                            GZIPInputStream(dataStream).readBytes()
+                        } else {
+                            dataStream.readBytes()
+                        }
                     }
                 }
 

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/HttpHeadRequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/HttpHeadRequestTest.kt
@@ -1,0 +1,34 @@
+package com.github.kittinunf.fuel
+
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
+import org.hamcrest.CoreMatchers.*
+import org.junit.Assert.assertThat
+import org.junit.Test
+import org.hamcrest.CoreMatchers.`is` as isEqualTo
+
+class HttpHeadRequestTest : BaseTestCase() {
+
+    @Test
+    fun httpHeadRequest() {
+        var req: Request? = null
+        var res: Response? = null
+        var data: Any? = null
+        var err: FuelError? = null
+
+        "https://www.google.com".httpHead().responseString { request, response, (resData, resErr) ->
+            req = request
+            res = response
+            data = resData
+            err = resErr
+        }
+
+        assertThat(res?.httpStatusCode, isEqualTo(200))
+        assertThat(req, notNullValue())
+        assertThat(res, notNullValue())
+        assertThat(err, nullValue())
+        assertThat(data, notNullValue())
+    }
+
+}


### PR DESCRIPTION
This fixes issue #177 

From RFC2619 (https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html)

The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response. The metainformation contained in the HTTP headers in response to a HEAD request SHOULD be identical to the information sent in response to a GET request. This method can be used for obtaining metainformation about the entity implied by the request without transferring the entity-body itself. This method is often used for testing hypertext links for validity, accessibility, and recent modification.

So, it is valid to return the Content-Encoding: gzip header, but we must not try to read the empty stream as a gzip stream.