### PR TITLE
Implement uploading data from InputStreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,14 @@ Fuel.upload("/post").sources { request, url ->
 }
 ```
 
+### Upload from an `InputStream`
+
+``` Kotlin
+Fuel.upload("/post").blob { request, url ->
+    Blob("filename.png", 1166976, { someObject.getInputStream() })
+}
+```
+
 ### Authentication
 
 * Support Basic Authentication right off the box

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Fuel.upload("/post").sources { request, url ->
 
 ``` Kotlin
 Fuel.upload("/post").blob { request, url ->
-    Blob("filename.png", 1166976, { someObject.getInputStream() })
+    Blob("filename.png", someObject.length, { someObject.getInputStream() })
 }
 ```
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Blob.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Blob.kt
@@ -1,0 +1,8 @@
+package com.github.kittinunf.fuel.core
+
+import java.io.InputStream
+
+data class Blob(
+        val name: String = "",
+        val length: Long,
+        val inputStream: () -> InputStream)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -1,12 +1,9 @@
 package com.github.kittinunf.fuel.core.requests
 
+import com.github.kittinunf.fuel.core.Blob
 import com.github.kittinunf.fuel.core.Request
-import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.util.copyTo
 import com.github.kittinunf.fuel.util.toHexString
-import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.FileInputStream
 import java.io.OutputStream
 import java.net.URL
 import java.net.URLConnection
@@ -24,27 +21,27 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
         outputStream.apply {
             val files = sourceCallback.invoke(request, request.url)
 
-            files.forEachIndexed { i, file ->
+            files.forEachIndexed { i, blob ->
                 val postFix = if (files.count() == 1) "" else "${i + 1}"
-                val fileName = request.names.getOrElse(i) { request.name + postFix }
+                val fieldName = request.names.getOrElse(i) { request.name + postFix }
 
                 contentLength += write("--$boundary")
                 contentLength += write(CRLF)
-                contentLength += write("Content-Disposition: form-data; name=\"$fileName\"; filename=\"${file.name}\"")
+                contentLength += write("Content-Disposition: form-data; name=\"$fieldName\"; filename=\"${blob.name}\"")
                 contentLength += write(CRLF)
-                contentLength += write("Content-Type: " + request.mediaTypes.getOrElse(i) { guessContentType(file) })
+                contentLength += write("Content-Type: " + request.mediaTypes.getOrElse(i) { guessContentType(blob) })
                 contentLength += write(CRLF)
                 contentLength += write(CRLF)
 
                 //input file data
                 if (outputStream != null) {
-                    FileInputStream(file).use {
+                    blob.inputStream().use {
                         it.copyTo(outputStream, BUFFER_SIZE) { writtenBytes ->
                             progressCallback?.invoke(contentLength + writtenBytes, totalLength)
                         }
                     }
                 }
-                contentLength += file.length()
+                contentLength += blob.length
                 contentLength += write(CRLF)
             }
 
@@ -74,15 +71,15 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
     val boundary = request.httpHeaders["Content-Type"]?.split("=", limit = 2)?.get(1) ?: System.currentTimeMillis().toHexString()
 
     var progressCallback: ((Long, Long) -> Unit)? = null
-    lateinit var sourceCallback: (Request, URL) -> Iterable<File>
+    lateinit var sourceCallback: (Request, URL) -> Iterable<Blob>
 
     init{
         request.bodyCallback = bodyCallBack
     }
 
-    private fun guessContentType(file: File): String {
+    private fun guessContentType(blob: Blob): String {
         try {
-            return URLConnection.guessContentTypeFromName(file.name) ?: "application/octet-stream"
+            return URLConnection.guessContentTypeFromName(blob.name) ?: "application/octet-stream"
         } catch (ex: NoClassDefFoundError) {
             // The MimetypesFileTypeMap class doesn't exists on old Android devices.
             return "application/octet-stream"

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
@@ -267,4 +267,41 @@ class RequestUploadTest : BaseTestCase() {
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response?.httpStatusCode, isEqualTo(statusCode))
     }
+
+    @Test
+    fun httpUploadWithNamedBlob() {
+        var request: Request? = null
+        var response: Response? = null
+        var data: Any? = null
+        var error: FuelError? = null
+
+
+        val file = File(currentDir, "lorem_ipsum_short.tmp")
+
+        manager.upload("/post", param = listOf("foo" to "bar"))
+
+                .blob { request, url ->
+                    request.name = "coolblob"
+                    Blob(inputStream = { file.inputStream() }, length = file.length(), name = file.name)
+                }
+                .responseString { req, res, result ->
+                    request = req
+                    response = res
+                    val (d, err) = result
+                    data = d
+                    error = err
+                    print(d)
+                }
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        val string = data as String
+        assertThat(string, containsString("coolblob"))
+
+        val statusCode = HttpURLConnection.HTTP_OK
+        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+    }
 }


### PR DESCRIPTION
Fixes #176.

Unfortunately there's no way to make `Blob`s compatible with existing `DataPart`s without breaking backwards compatibility due to the public `file` property.