### PR TITLE
Filter out null keys in headerFields map

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -42,7 +42,7 @@ class HttpClient(val proxy: Proxy? = null) : Client {
 
             return response.apply {
 
-                httpResponseHeaders = connection.headerFields ?: emptyMap()
+                httpResponseHeaders = connection.headerFields.filterKeys { it != null } ?: emptyMap()
                 httpContentLength = connection.contentLength.toLong()
 
                 val contentEncoding = connection.contentEncoding ?: ""


### PR DESCRIPTION
`URLConnection`s `getHeaderFields()` contains a null key for the HTTP response code. I have no idea why, and other libraries sort out null keys, so I added it here. It's not Fuel's fault, it's just the way `URLConnection works for some reason

Fixes issue #217