### PR TITLE
Add two DataPart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,16 +350,13 @@ Fuel.upload("/post").sources { request, url ->
 ```Kotlin
 Fuel.upload("/post").sources { request, url ->
     listOf(
-    	//DataPart takes a file, and you can specify the name and/or type
+        //DataPart takes a file, and you can specify the name and/or type
         DataPart(File.createTempFile("temp1", ".tmp"), "image/jpeg"), 
         DataPart(File.createTempFile("temp2", ".tmp"), "file2"),
-	DataPart(File.createTempFile("temp3", ".tmp"), "third-file", "image/jpeg")
-	
+        DataPart(File.createTempFile("temp3", ".tmp"), "third-file", "image/jpeg")
     )
-}.name {
-    "temp"
 }.responseString { request, response, result ->
-
+    ...
 }
 ```
 ### Upload a multipart form without a file
@@ -370,7 +367,7 @@ Fuel.upload("/post", param = formData)
     //Upload normally requires a file, but we can give it an empty list of `DataPart`
     .dataParts{ request, url -> listOf<DataPart>() } 
     .responseString { request, response, result ->
-	...
+        ...
     }
 ```
 	

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Fuel.upload("/post").sources { request, url ->
 val formData = listOf("Email" to "mail@example.com", "Name" to "Joe Smith" )
 Fuel.upload("/post", param = formData)
     //Upload normally requires a file, but we can give it an empty list of `DataPart`
-    .dataParts{ request, url -> listOf<DataPart>() } 
+    .dataParts { request, url -> listOf<DataPart>() } 
     .responseString { request, response, result ->
         ...
     }

--- a/README.md
+++ b/README.md
@@ -346,7 +346,31 @@ Fuel.upload("/post").sources { request, url ->
 
 }
 ```
+### Specify custom field names for files
+```Kotlin
+Fuel.upload("/post").sources { request, url ->
+    listOf(
+        DataPart(File.createTempFile("temp1", ".tmp"), "file1"), 
+        DataPart(File.createTempFile("temp2", ".tmp"), "file2")
+    )
+}.name {
+    "temp"
+}.responseString { request, response, result ->
 
+}
+```
+### Upload a multipart form without a file
+
+``` Kotlin
+val formData = listOf("Email" to "mail@example.com", "Name" to "Joe Smith" )
+Fuel.upload("/post", param = formData)
+    //Upload normally requires a file, but we can give it an empty list of `DataPart`
+    .dataParts{ request, url -> listOf<DataPart>() } 
+    .responseString { request, response, result ->
+	...
+    }
+```
+	
 ### Upload from an `InputStream`
 
 ``` Kotlin

--- a/README.md
+++ b/README.md
@@ -350,8 +350,11 @@ Fuel.upload("/post").sources { request, url ->
 ```Kotlin
 Fuel.upload("/post").sources { request, url ->
     listOf(
-        DataPart(File.createTempFile("temp1", ".tmp"), "file1"), 
-        DataPart(File.createTempFile("temp2", ".tmp"), "file2")
+    	//DataPart takes a file, and you can specify the name and/or type
+        DataPart(File.createTempFile("temp1", ".tmp"), "image/jpeg"), 
+        DataPart(File.createTempFile("temp2", ".tmp"), "file2"),
+	DataPart(File.createTempFile("temp3", ".tmp"), "third-file", "image/jpeg")
+	
     )
 }.name {
     "temp"


### PR DESCRIPTION
The [custom form DataPart](https://github.com/kittinunf/Fuel/pull/162) allows for specifying custom file names and for uploading a multipart form with no files at all.

I've added an example of each to the readme, so users will know that Fuel has this functionality