### PR TITLE
Refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
         publish_version = '1.9.0'
 
         //dependencies version
-        kotlin_version = '1.1.3'
+        kotlin_version = '1.1.4'
         result_version = '1.1.0'
         rxjava_version = '2.1.0'
         archLifecycleVersion = "1.0.0-alpha3"

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
         publish_version = '1.9.0'
 
         //dependencies version
-        kotlin_version = '1.1.4'
+        kotlin_version = '1.1.4-3'
         result_version = '1.1.0'
         rxjava_version = '2.1.0'
         archLifecycleVersion = "1.0.0-alpha3"

--- a/fuel-android/src/test/kotlin/com/github/kittinunf/fuel/android/RequestAndroidAsyncTest.kt
+++ b/fuel-android/src/test/kotlin/com/github/kittinunf/fuel/android/RequestAndroidAsyncTest.kt
@@ -99,7 +99,7 @@ class RequestAndroidAsyncTest : BaseTestCase() {
         assertThat(data as String, isA(String::class.java))
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -130,7 +130,7 @@ class RequestAndroidAsyncTest : BaseTestCase() {
         assertThat((data as Json).obj(), isA(JSONObject::class.java))
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -164,7 +164,7 @@ class RequestAndroidAsyncTest : BaseTestCase() {
         assertThat((data as Json).obj(), isA(JSONObject::class.java))
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(res?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(res?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -193,7 +193,7 @@ class RequestAndroidAsyncTest : BaseTestCase() {
         assertThat(data, nullValue())
 
         val statusCode = HttpURLConnection.HTTP_NOT_FOUND
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -225,7 +225,7 @@ class RequestAndroidAsyncTest : BaseTestCase() {
         assertThat(data, nullValue())
 
         val statusCode = HttpURLConnection.HTTP_NOT_FOUND
-        assertThat(res?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(res?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -255,7 +255,7 @@ class RequestAndroidAsyncTest : BaseTestCase() {
         assertThat((data as HttpBinHeadersModel).headers.isNotEmpty(), isEqualTo(true))
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -291,7 +291,7 @@ class RequestAndroidAsyncTest : BaseTestCase() {
         assertThat((data as HttpBinHeadersModel).headers.isNotEmpty(), isEqualTo(true))
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(res?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(res?.statusCode, isEqualTo(statusCode))
     }
 
 }

--- a/fuel-android/src/test/kotlin/com/github/kittinunf/fuel/android/RequestAndroidSyncTest.kt
+++ b/fuel-android/src/test/kotlin/com/github/kittinunf/fuel/android/RequestAndroidSyncTest.kt
@@ -51,7 +51,7 @@ class RequestAndroidSyncTest : BaseTestCase() {
         assertThat(data, notNullValue())
         assertThat(data as String, isA(String::class.java))
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }
 
     @Test
@@ -66,7 +66,7 @@ class RequestAndroidSyncTest : BaseTestCase() {
         assertThat(data as Json, isA(Json::class.java))
         assertThat(data.obj(), isA(JSONObject::class.java))
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }
 
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/Fuel.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/Fuel.kt
@@ -28,186 +28,141 @@ class Fuel {
         //convenience methods
         //get
         @JvmStatic @JvmOverloads
-        fun get(path: String, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.GET, path, parameters)
-        }
+        fun get(path: String, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.GET, path, parameters)
 
         @JvmStatic @JvmOverloads
-        fun get(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.GET, convertible, parameters)
-        }
+        fun get(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.GET, convertible, parameters)
 
         //post
         @JvmStatic @JvmOverloads
-        fun post(path: String, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.POST, path, parameters)
-        }
+        fun post(path: String, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.POST, path, parameters)
 
         @JvmStatic @JvmOverloads
-        fun post(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.POST, convertible, parameters)
-        }
+        fun post(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.POST, convertible, parameters)
 
         //put
         @JvmStatic @JvmOverloads
-        fun put(path: String, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.PUT, path, parameters)
-        }
+        fun put(path: String, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.PUT, path, parameters)
 
         @JvmStatic @JvmOverloads
-        fun put(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.PUT, convertible, parameters)
-        }
+        fun put(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.PUT, convertible, parameters)
 
         //patch
         @JvmStatic @JvmOverloads
-        fun patch(path: String, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.PATCH, path, parameters)
-        }
+        fun patch(path: String, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.PATCH, path, parameters)
 
         @JvmStatic @JvmOverloads
-        fun patch(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.PATCH, convertible, parameters)
-        }
+        fun patch(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.PATCH, convertible, parameters)
 
         //delete
         @JvmStatic @JvmOverloads
-        fun delete(path: String, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.DELETE, path, parameters)
-        }
+        fun delete(path: String, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.DELETE, path, parameters)
 
         @JvmStatic @JvmOverloads
-        fun delete(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.DELETE, convertible, parameters)
-        }
+        fun delete(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.DELETE, convertible, parameters)
 
         //download
         @JvmStatic @JvmOverloads
-        fun download(path: String, parameters: List<Pair<String, Any?>>? = null): Request {
-            return FuelManager.instance.download(path, parameters)
-        }
+        fun download(path: String, parameters: List<Pair<String, Any?>>? = null): Request =
+                FuelManager.instance.download(path, parameters)
 
         @JvmStatic @JvmOverloads
-        fun download(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request {
-            return download(convertible.path, parameters)
-        }
+        fun download(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
+                download(convertible.path, parameters)
 
         //upload
         @JvmStatic @JvmOverloads
-        fun upload(path: String, method: Method = Method.POST, parameters: List<Pair<String, Any?>>? = null): Request {
-            return FuelManager.instance.upload(path, method, parameters)
-        }
+        fun upload(path: String, method: Method = Method.POST, parameters: List<Pair<String, Any?>>? = null): Request =
+                FuelManager.instance.upload(path, method, parameters)
 
         @JvmStatic @JvmOverloads
-        fun upload(convertible: PathStringConvertible, method: Method = Method.POST, parameters: List<Pair<String, Any?>>? = null): Request {
-            return upload(convertible.path, method, parameters)
-        }
+        fun upload(convertible: PathStringConvertible, method: Method = Method.POST, parameters: List<Pair<String, Any?>>? = null): Request =
+                upload(convertible.path, method, parameters)
 
         //head
         @JvmStatic @JvmOverloads
-        fun head(path: String, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.HEAD, path, parameters)
-        }
+        fun head(path: String, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.HEAD, path, parameters)
 
         @JvmStatic @JvmOverloads
-        fun head(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(Method.HEAD, convertible, parameters)
-        }
+        fun head(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(Method.HEAD, convertible, parameters)
 
         //request
-        private fun request(method: Method, path: String, parameters: List<Pair<String, Any?>>? = null): Request {
-            return FuelManager.instance.request(method, path, parameters)
-        }
+        private fun request(method: Method, path: String, parameters: List<Pair<String, Any?>>? = null): Request =
+                FuelManager.instance.request(method, path, parameters)
 
-        private fun request(method: Method, convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request {
-            return request(method, convertible.path, parameters)
-        }
+        private fun request(method: Method, convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
+                request(method, convertible.path, parameters)
 
         @JvmStatic
-        fun request(convertible: RequestConvertible): Request {
-            return FuelManager.instance.request(convertible)
-        }
+        fun request(convertible: RequestConvertible): Request = FuelManager.instance.request(convertible)
 
     }
 
 }
 
 @JvmOverloads
-fun String.httpGet(parameters: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.get(this, parameters)
-}
+fun String.httpGet(parameters: List<Pair<String, Any?>>? = null): Request = Fuel.get(this, parameters)
 
 @JvmOverloads
-fun Fuel.PathStringConvertible.httpGet(parameter: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.get(this, parameter)
-}
+fun Fuel.PathStringConvertible.httpGet(parameter: List<Pair<String, Any?>>? = null): Request = Fuel.get(this, parameter)
 
 @JvmOverloads
-fun String.httpPost(parameters: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.post(this, parameters)
-}
+fun String.httpPost(parameters: List<Pair<String, Any?>>? = null): Request = Fuel.post(this, parameters)
 
 @JvmOverloads
-fun Fuel.PathStringConvertible.httpPost(parameter: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.post(this, parameter)
-}
+fun Fuel.PathStringConvertible.httpPost(parameter: List<Pair<String, Any?>>? = null): Request =
+        Fuel.post(this, parameter)
 
 @JvmOverloads
-fun String.httpPut(parameters: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.put(this, parameters)
-}
+fun String.httpPut(parameters: List<Pair<String, Any?>>? = null): Request = Fuel.put(this, parameters)
 
 @JvmOverloads
-fun Fuel.PathStringConvertible.httpPut(parameter: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.put(this, parameter)
-}
+fun Fuel.PathStringConvertible.httpPut(parameter: List<Pair<String, Any?>>? = null): Request = Fuel.put(this, parameter)
 
 @JvmOverloads
-fun String.httpPatch(parameters: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.patch(this, parameters)
-}
+fun String.httpPatch(parameters: List<Pair<String, Any?>>? = null): Request = Fuel.patch(this, parameters)
 
 @JvmOverloads
-fun Fuel.PathStringConvertible.httpPatch(parameter: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.patch(this, parameter)
-}
+fun Fuel.PathStringConvertible.httpPatch(parameter: List<Pair<String, Any?>>? = null): Request =
+        Fuel.patch(this, parameter)
 
 @JvmOverloads
-fun String.httpDelete(parameters: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.delete(this, parameters)
-}
+fun String.httpDelete(parameters: List<Pair<String, Any?>>? = null): Request = Fuel.delete(this, parameters)
 
 @JvmOverloads
-fun Fuel.PathStringConvertible.httpDelete(parameter: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.delete(this, parameter)
-}
+fun Fuel.PathStringConvertible.httpDelete(parameter: List<Pair<String, Any?>>? = null): Request =
+        Fuel.delete(this, parameter)
 
 @JvmOverloads
-fun String.httpDownload(parameter: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.download(this, parameter)
-}
+fun String.httpDownload(parameter: List<Pair<String, Any?>>? = null): Request = Fuel.download(this, parameter)
 
 @JvmOverloads
-fun Fuel.PathStringConvertible.httpDownload(parameter: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.download(this, parameter)
-}
+fun Fuel.PathStringConvertible.httpDownload(parameter: List<Pair<String, Any?>>? = null): Request =
+        Fuel.download(this, parameter)
 
 @JvmOverloads
-fun String.httpUpload(method: Method = Method.POST, parameters: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.upload(this, method, parameters)
-}
+fun String.httpUpload(method: Method = Method.POST, parameters: List<Pair<String, Any?>>? = null): Request =
+        Fuel.upload(this, method, parameters)
 
 @JvmOverloads
-fun Fuel.PathStringConvertible.httpUpload(method: Method = Method.POST, parameters: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.upload(this, method, parameters)
-}
+fun Fuel.PathStringConvertible.httpUpload(method: Method = Method.POST, parameters: List<Pair<String, Any?>>? = null): Request =
+        Fuel.upload(this, method, parameters)
 
 @JvmOverloads
-fun Fuel.PathStringConvertible.httpHead(parameter: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.head(this, parameter)
-}
+fun Fuel.PathStringConvertible.httpHead(parameter: List<Pair<String, Any?>>? = null): Request =
+        Fuel.head(this, parameter)
 
 @JvmOverloads
-fun String.httpHead(parameters: List<Pair<String, Any?>>? = null): Request {
-    return Fuel.head(this, parameters)
-}
+fun String.httpHead(parameters: List<Pair<String, Any?>>? = null): Request = Fuel.head(this, parameters)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
@@ -4,5 +4,5 @@ import java.io.File
 
 data class DataPart(
         val file: File,
-        val name: String = file.name.split(".").getOrElse(0) { "" },
+        val name: String = file.nameWithoutExtension,
         val type: String = "")

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
@@ -2,9 +2,7 @@ package com.github.kittinunf.fuel.core
 
 import com.github.kittinunf.fuel.core.requests.AsyncTaskRequest
 import com.github.kittinunf.result.Result
-import java.io.ByteArrayInputStream
 import java.io.InputStream
-import java.io.InputStreamReader
 import java.io.Reader
 
 interface Deserializable<out T : Any> {
@@ -63,7 +61,7 @@ private fun <T : Any, U : Deserializable<T>> Request.response(deserializable: U,
                 deliverable.fold({
                     success(this@response, response, it)
                 }, {
-                    failure(this@response, response, FuelError().apply { exception = it })
+                    failure(this@response, response, FuelError(it))
                 })
             }
         }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -1,7 +1,6 @@
 package com.github.kittinunf.fuel.core
 
 import com.github.kittinunf.fuel.Fuel
-import com.github.kittinunf.fuel.util.toHexString
 import java.net.MalformedURLException
 import java.net.URI
 import java.net.URISyntaxException
@@ -29,7 +28,7 @@ class Encoding(val httpMethod: Method,
                 modifiedPath += (querySign + queryParamString)
             }
             requestType == Request.Type.UPLOAD -> {
-                val boundary = System.currentTimeMillis().toHexString()
+                val boundary = System.currentTimeMillis().toString(16)
                 headerPairs += "Content-Type" to "multipart/form-data; boundary=" + boundary
             }
             else -> {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -36,12 +36,13 @@ class Encoding(val httpMethod: Method,
                 data = queryFromParameters(parameters)
             }
         }
-        Request().apply {
-            httpMethod = method
-            this.path = modifiedPath
-            this.url = createUrl(modifiedPath)
-            this.type = requestType
-            this.parameters = parameters ?: emptyList()
+        Request(
+                httpMethod = method,
+                path = modifiedPath,
+                url = createUrl(modifiedPath),
+                type = requestType,
+                parameters = parameters ?: emptyList()
+        ).apply {
             header(headerPairs, false)
             if (data != null) body(data ?: "")
         }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -37,7 +37,7 @@ class Encoding(val httpMethod: Method,
             }
         }
         Request(
-                httpMethod = method,
+                method = method,
                 path = modifiedPath,
                 url = createUrl(modifiedPath),
                 type = requestType,

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -15,7 +15,7 @@ class Encoding(val httpMethod: Method,
     private val encoder: (Method, String, List<Pair<String, Any?>>?) -> Request = { method, path, parameters ->
         var modifiedPath = path
         var data: String? = null
-        val headerPairs: MutableMap<String, Any> = defaultHeaders.toMutableMap()
+        val headerPairs = defaultHeaders.toMutableMap()
         when {
             encodeParameterInUrl(method) -> {
                 var querySign = ""
@@ -44,7 +44,7 @@ class Encoding(val httpMethod: Method,
                 parameters = parameters ?: emptyList()
         ).apply {
             header(headerPairs, false)
-            if (data != null) body(data ?: "")
+            if (data != null) body(data!!)
         }
 
     }
@@ -75,5 +75,5 @@ class Encoding(val httpMethod: Method,
             .filterNot { it.second == null }
             .joinToString("&") { "${it.first}=${it.second}" }
 
-    private val defaultHeaders: Map<String, Any> = mapOf("Accept-Encoding" to "compress;q=0.5, gzip;q=1.0")
+    private val defaultHeaders = mapOf("Accept-Encoding" to "compress;q=0.5, gzip;q=1.0")
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -6,35 +6,36 @@ import java.net.MalformedURLException
 import java.net.URI
 import java.net.URISyntaxException
 import java.net.URL
-import kotlin.properties.Delegates
 
-class Encoding : Fuel.RequestConvertible {
+class Encoding(var httpMethod: Method,
+               var urlString: String,
+               var requestType: Request.Type = Request.Type.REQUEST,
+               var baseUrlString: String? = null,
+               var parameters: List<Pair<String, Any?>>? = null) : Fuel.RequestConvertible {
 
-    var requestType: Request.Type = Request.Type.REQUEST
-    var httpMethod: Method by Delegates.notNull()
-    var baseUrlString: String? = null
-    var urlString: String by Delegates.notNull()
-    var parameters: List<Pair<String, Any?>>? = null
-
-    var encoder: (Method, String, List<Pair<String, Any?>>?) -> Request = { method, path, parameters ->
+    private val encoder: (Method, String, List<Pair<String, Any?>>?) -> Request = { method, path, parameters ->
         var modifiedPath = path
         var data: String? = null
         val headerPairs: MutableMap<String, Any> = defaultHeaders()
-        if (encodeParameterInUrl(method)) {
-            var querySign = ""
-            val queryParamString = queryFromParameters(parameters)
-            if (queryParamString.isNotEmpty()) {
-                if (path.count() > 0) {
-                    querySign = if (path.last() == '?') "" else "?"
+        when {
+            encodeParameterInUrl(method) -> {
+                var querySign = ""
+                val queryParamString = queryFromParameters(parameters)
+                if (queryParamString.isNotEmpty()) {
+                    if (path.count() > 0) {
+                        querySign = if (path.last() == '?') "" else "?"
+                    }
                 }
+                modifiedPath += (querySign + queryParamString)
             }
-            modifiedPath += (querySign + queryParamString)
-        } else if (requestType == Request.Type.UPLOAD) {
-            val boundary = System.currentTimeMillis().toHexString()
-            headerPairs += "Content-Type" to "multipart/form-data; boundary=" + boundary
-        } else {
-            headerPairs += "Content-Type" to "application/x-www-form-urlencoded"
-            data = queryFromParameters(parameters)
+            requestType == Request.Type.UPLOAD -> {
+                val boundary = System.currentTimeMillis().toHexString()
+                headerPairs += "Content-Type" to "multipart/form-data; boundary=" + boundary
+            }
+            else -> {
+                headerPairs += "Content-Type" to "application/x-www-form-urlencoded"
+                data = queryFromParameters(parameters)
+            }
         }
         Request().apply {
             httpMethod = method
@@ -65,23 +66,15 @@ class Encoding : Fuel.RequestConvertible {
         return URL(uri.toASCIIString())
     }
 
-    private fun encodeParameterInUrl(method: Method): Boolean {
-        when (method) {
-            Method.GET, Method.DELETE, Method.HEAD -> return true
-            else -> return false
-        }
+    private fun encodeParameterInUrl(method: Method): Boolean = when (method) {
+        Method.GET, Method.DELETE, Method.HEAD -> true
+        else -> false
     }
 
-    private fun queryFromParameters(params: List<Pair<String, Any?>>?): String {
-        return params?.let {
-            params.filterNot { it.second == null }
-                    .mapTo(mutableListOf()) { "${it.first}=${it.second}" }
-                    .joinToString("&")
-        } ?: ""
-    }
+    private fun queryFromParameters(params: List<Pair<String, Any?>>?): String = params.orEmpty()
+            .filterNot { it.second == null }
+            .mapTo(mutableListOf()) { "${it.first}=${it.second}" }
+            .joinToString("&")
 
-    companion object {
-        private fun defaultHeaders(): MutableMap<String, Any> = mutableMapOf("Accept-Encoding" to "compress;q=0.5, gzip;q=1.0")
-    }
-
+    private fun defaultHeaders(): MutableMap<String, Any> = mutableMapOf("Accept-Encoding" to "compress;q=0.5, gzip;q=1.0")
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -15,7 +15,7 @@ class Encoding(val httpMethod: Method,
     private val encoder: (Method, String, List<Pair<String, Any?>>?) -> Request = { method, path, parameters ->
         var modifiedPath = path
         var data: String? = null
-        val headerPairs: MutableMap<String, Any> = defaultHeaders()
+        val headerPairs: MutableMap<String, Any> = defaultHeaders.toMutableMap()
         when {
             encodeParameterInUrl(method) -> {
                 var querySign = ""
@@ -73,8 +73,7 @@ class Encoding(val httpMethod: Method,
 
     private fun queryFromParameters(params: List<Pair<String, Any?>>?): String = params.orEmpty()
             .filterNot { it.second == null }
-            .mapTo(mutableListOf()) { "${it.first}=${it.second}" }
-            .joinToString("&")
+            .joinToString("&") { "${it.first}=${it.second}" }
 
-    private fun defaultHeaders(): MutableMap<String, Any> = mutableMapOf("Accept-Encoding" to "compress;q=0.5, gzip;q=1.0")
+    private val defaultHeaders: Map<String, Any> = mapOf("Accept-Encoding" to "compress;q=0.5, gzip;q=1.0")
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -7,11 +7,11 @@ import java.net.URI
 import java.net.URISyntaxException
 import java.net.URL
 
-class Encoding(var httpMethod: Method,
-               var urlString: String,
-               var requestType: Request.Type = Request.Type.REQUEST,
-               var baseUrlString: String? = null,
-               var parameters: List<Pair<String, Any?>>? = null) : Fuel.RequestConvertible {
+class Encoding(val httpMethod: Method,
+               val urlString: String,
+               val requestType: Request.Type = Request.Type.REQUEST,
+               val baseUrlString: String? = null,
+               val parameters: List<Pair<String, Any?>>? = null) : Fuel.RequestConvertible {
 
     private val encoder: (Method, String, List<Pair<String, Any?>>?) -> Request = { method, path, parameters ->
         var modifiedPath = path

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Environment.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Environment.kt
@@ -6,12 +6,10 @@ interface Environment {
     var callbackExecutor: Executor
 }
 
-fun createEnvironment(): Environment {
-    try {
-        return Class.forName(AndroidEnvironmentClass).newInstance() as Environment
-    } catch(exception: ClassNotFoundException) {
-        return DefaultEnvironment()
-    }
+fun createEnvironment(): Environment = try {
+    Class.forName(AndroidEnvironmentClass).newInstance() as Environment
+} catch(exception: ClassNotFoundException) {
+    DefaultEnvironment()
 }
 
 class DefaultEnvironment : Environment {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
@@ -1,6 +1,6 @@
 package com.github.kittinunf.fuel.core
 
-class FuelError(val exception: Exception, val errorData: ByteArray = ByteArray(0), val response: Response = Response())
+class FuelError(val exception: Exception, val errorData: ByteArray = ByteArray(0), val response: Response = Response.error())
     : Exception("FuelError", exception) {
     override fun toString(): String = "${exception.javaClass.canonicalName}: ${exception.message ?: "<no message>"}"
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
@@ -1,6 +1,6 @@
 package com.github.kittinunf.fuel.core
 
 class FuelError(val exception: Exception, val errorData: ByteArray = ByteArray(0), val response: Response = Response.error())
-    : Exception("FuelError", exception) {
+    : Exception(exception) {
     override fun toString(): String = "${exception.javaClass.canonicalName}: ${exception.message ?: "<no message>"}"
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
@@ -1,11 +1,6 @@
 package com.github.kittinunf.fuel.core
 
-import kotlin.properties.Delegates
-
-class FuelError : Exception() {
-    var exception: Exception by Delegates.notNull()
-    var errorData = ByteArray(0)
-    var response = Response()
-
+class FuelError(val exception: Exception, val errorData: ByteArray = ByteArray(0), val response: Response = Response())
+    : Exception("FuelError", exception) {
     override fun toString(): String = "${exception.javaClass.canonicalName}: ${exception.message ?: "<no message>"}"
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
@@ -11,7 +11,11 @@ import java.security.KeyStore
 import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import javax.net.ssl.*
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManagerFactory
 
 class FuelManager {
     var client: Client by readWriteLazy { HttpClient(proxy) }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
@@ -69,7 +69,7 @@ class FuelManager {
         ).request)
 
         request.client = client
-        request.httpHeaders += baseHeaders.orEmpty()
+        request.headers += baseHeaders.orEmpty()
         request.socketFactory = socketFactory
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
@@ -92,7 +92,7 @@ class FuelManager {
         ).request
 
         request.client = client
-        request.httpHeaders += baseHeaders.orEmpty()
+        request.headers += baseHeaders.orEmpty()
         request.socketFactory = socketFactory
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
@@ -112,7 +112,7 @@ class FuelManager {
         ).request
 
         request.client = client
-        request.httpHeaders += baseHeaders.orEmpty()
+        request.headers += baseHeaders.orEmpty()
         request.socketFactory = socketFactory
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()
@@ -125,7 +125,7 @@ class FuelManager {
     fun request(convertible: Fuel.RequestConvertible): Request {
         val request = convertible.request
         request.client = client
-        request.httpHeaders += baseHeaders.orEmpty()
+        request.headers += baseHeaders.orEmpty()
         request.socketFactory = socketFactory
         request.hostnameVerifier = hostnameVerifier
         request.executor = createExecutor()

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
@@ -11,14 +11,9 @@ import java.security.KeyStore
 import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import javax.net.ssl.HostnameVerifier
-import javax.net.ssl.HttpsURLConnection
-import javax.net.ssl.SSLContext
-import javax.net.ssl.SSLSocketFactory
-import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.*
 
 class FuelManager {
-
     var client: Client by readWriteLazy { HttpClient(proxy) }
     var proxy: Proxy? = null
     var basePath: String? = null
@@ -62,12 +57,12 @@ class FuelManager {
     var callbackExecutor: Executor by readWriteLazy { createEnvironment().callbackExecutor }
 
     fun request(method: Method, path: String, param: List<Pair<String, Any?>>? = null): Request {
-        val request = request(Encoding().apply {
-            httpMethod = method
-            baseUrlString = basePath
-            urlString = path
-            parameters = if (param == null) baseParams else baseParams + param
-        })
+        val request = request(Encoding(
+                httpMethod = method,
+                urlString = path,
+                baseUrlString = basePath,
+                parameters = if (param == null) baseParams else baseParams + param
+        ).request)
 
         request.client = client
         request.httpHeaders += baseHeaders.orEmpty()
@@ -85,13 +80,13 @@ class FuelManager {
     }
 
     fun download(path: String, param: List<Pair<String, Any?>>? = null): Request {
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            baseUrlString = basePath
-            urlString = path
-            parameters = if (param == null) baseParams else baseParams + param
-            requestType = Request.Type.DOWNLOAD
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                urlString = path,
+                requestType = Request.Type.DOWNLOAD,
+                baseUrlString = basePath,
+                parameters = if (param == null) baseParams else baseParams + param
+        ).request
 
         request.client = client
         request.httpHeaders += baseHeaders.orEmpty()
@@ -105,13 +100,13 @@ class FuelManager {
     }
 
     fun upload(path: String, method: Method = Method.POST, param: List<Pair<String, Any?>>? = null): Request {
-        val request = Encoding().apply {
-            httpMethod = method
-            baseUrlString = basePath
-            urlString = path
-            parameters = if (param == null) baseParams else baseParams + param
-            requestType = Request.Type.UPLOAD
-        }.request
+        val request = Encoding(
+                httpMethod = method,
+                urlString = path,
+                requestType = Request.Type.UPLOAD,
+                baseUrlString = basePath,
+                parameters = if (param == null) baseParams else baseParams + param
+        ).request
 
         request.client = client
         request.httpHeaders += baseHeaders.orEmpty()

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelManager.kt
@@ -51,7 +51,7 @@ class FuelManager {
     private val responseInterceptors: MutableList<((Request, Response) -> Response) -> ((Request, Response) -> Response)> =
             mutableListOf(redirectResponseInterceptor(this), validatorResponseInterceptor(200..299))
 
-    fun createExecutor() = if (Fuel.testConfiguration.blocking) SameThreadExecutorService() else executor
+    private fun createExecutor() = if (Fuel.testConfiguration.blocking) SameThreadExecutorService() else executor
 
     //callback executor
     var callbackExecutor: Executor by readWriteLazy { createEnvironment().callbackExecutor }
@@ -75,9 +75,8 @@ class FuelManager {
         return request
     }
 
-    fun request(method: Method, convertible: Fuel.PathStringConvertible, param: List<Pair<String, Any?>>? = null): Request {
-        return request(method, convertible.path, param)
-    }
+    fun request(method: Method, convertible: Fuel.PathStringConvertible, param: List<Pair<String, Any?>>? = null): Request =
+            request(method, convertible.path, param)
 
     fun download(path: String, param: List<Pair<String, Any?>>? = null): Request {
         val request = Encoding(

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -21,17 +21,23 @@ import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSocketFactory
 
 class Request(
-        val httpMethod: Method,
+        val method: Method,
         val path: String,
         val url: URL,
         var type: Type = Type.REQUEST,
-        val httpHeaders: MutableMap<String, String> = mutableMapOf<String, String>(),
-        val parameters: List<Pair<String, Any?>> = listOf<Pair<String, Any?>>(),
+        val headers: MutableMap<String, String> = mutableMapOf(),
+        val parameters: List<Pair<String, Any?>> = listOf(),
         var name: String = "",
-        val names: MutableList<String> = mutableListOf<String>(),
-        val mediaTypes: MutableList<String> = mutableListOf<String>(),
+        val names: MutableList<String> = mutableListOf(),
+        val mediaTypes: MutableList<String> = mutableListOf(),
         var timeoutInMillisecond: Int = 15000,
         var timeoutReadInMillisecond: Int = timeoutInMillisecond) : Fuel.RequestConvertible {
+
+    @Deprecated(replaceWith = ReplaceWith("method"), message = "http naming is deprecated, use 'method' instead")
+    val httpMethod get() = method
+
+    @Deprecated(replaceWith = ReplaceWith("headers"), message = "http naming is deprecated, use 'headers' instead")
+    val httpHeaders get() = headers
 
     enum class Type {
         REQUEST,
@@ -87,7 +93,7 @@ class Request(
     fun header(vararg pairs: Pair<String, Any>?): Request {
         pairs.forEach {
             if (it != null)
-                httpHeaders.plusAssign(Pair(it.first, it.second.toString()))
+                headers += Pair(it.first, it.second.toString())
         }
         return this
     }
@@ -97,8 +103,8 @@ class Request(
     internal fun header(pairs: Map<String, Any>?, replace: Boolean): Request {
         pairs?.forEach {
             it.let {
-                if (!httpHeaders.containsKey(it.key) || replace) {
-                    httpHeaders.plusAssign(Pair(it.key, it.value.toString()))
+                if (!headers.containsKey(it.key) || replace) {
+                    headers += Pair(it.key, it.value.toString())
                 }
             }
         }
@@ -229,8 +235,8 @@ class Request(
 
     override fun toString(): String = buildString {
         appendln("\"Body : ${if (getHttpBody().isNotEmpty()) String(getHttpBody()) else "(empty)"}\"")
-        appendln("\"Headers : (${httpHeaders.size})\"")
-        for ((key, value) in httpHeaders) {
+        appendln("\"Headers : (${headers.size})\"")
+        for ((key, value) in headers) {
             appendln("$key : $value")
         }
     }
@@ -239,8 +245,8 @@ class Request(
         append("$ curl -i")
 
         //method
-        if (httpMethod != Method.GET) {
-            append("-X $httpMethod")
+        if (method != Method.GET) {
+            append("-X $method")
         }
 
         //body
@@ -250,7 +256,7 @@ class Request(
         }
 
         //headers
-        for ((key, value) in httpHeaders) {
+        for ((key, value) in headers) {
             append("-H \"$key:$value\"")
         }
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -59,7 +59,7 @@ class Request : Fuel.RequestConvertible {
     val mediaTypes = mutableListOf<String>()
 
     //underlying task request
-    val taskRequest: TaskRequest by lazy {
+    internal val taskRequest: TaskRequest by lazy {
         when (type) {
             Type.DOWNLOAD -> DownloadTaskRequest(this)
             Type.UPLOAD -> UploadTaskRequest(this)
@@ -194,10 +194,8 @@ class Request : Fuel.RequestConvertible {
         val uploadTaskRequest = taskRequest as? UploadTaskRequest ?: throw IllegalStateException("source is only used with RequestType.UPLOAD")
         val files = sources.invoke(request, request.url)
 
-        uploadTaskRequest.apply {
-            sourceCallback = { _, _ ->
-                files.map { Blob(it.name, it.length(), { it.inputStream() }) }
-            }
+        uploadTaskRequest.sourceCallback = { _, _ ->
+            files.map { Blob(it.name, it.length(), it::inputStream) }
         }
 
         return this

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
@@ -5,17 +5,14 @@ import java.io.IOException
 import java.io.InputStream
 import java.net.URL
 
-class Response {
-
-    lateinit var url: URL
-
-    var httpStatusCode = -1
-    var httpResponseMessage = ""
-    var httpResponseHeaders = emptyMap<String, List<String>>()
-    var httpContentLength = 0L
-
-    //data
-    var dataStream: InputStream = ByteArrayInputStream(ByteArray(0))
+class Response(
+        val url: URL,
+        val httpStatusCode: Int = -1,
+        val httpResponseMessage: String = "",
+        val httpResponseHeaders: Map<String, List<String>> = emptyMap<String, List<String>>(),
+        val httpContentLength: Long = 0L,
+        val dataStream: InputStream = ByteArrayInputStream(ByteArray(0))
+) {
     val data: ByteArray by lazy {
         try {
             dataStream.use { dataStream.readBytes() }
@@ -24,26 +21,18 @@ class Response {
         }
     }
 
-    override fun toString(): String {
-        val elements = mutableListOf("<-- $httpStatusCode ($url)")
-
-        //response message
-        elements.add("Response : $httpResponseMessage")
-
-        //content length
-        elements.add("Length : $httpContentLength")
-
-        //body
-        elements.add("Body : ${if (data.isNotEmpty()) String(data) else "(empty)"}")
-
-        //headers
-        //headers
-        elements.add("Headers : (${httpResponseHeaders.size})")
+    override fun toString(): String = buildString {
+        appendln("<-- $httpStatusCode ($url)")
+        appendln("Response : $httpResponseMessage")
+        appendln("Length : $httpContentLength")
+        appendln("Body : ${if (data.isNotEmpty()) String(data) else "(empty)"}")
+        appendln("Headers : (${httpResponseHeaders.size})")
         for ((key, value) in httpResponseHeaders) {
-            elements.add("$key : $value")
+            appendln("$key : $value")
         }
-
-        return elements.joinToString("\n")
     }
 
+    companion object {
+        fun error(): Response = Response(URL("http://."))
+    }
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
@@ -7,12 +7,24 @@ import java.net.URL
 
 class Response(
         val url: URL,
-        val httpStatusCode: Int = -1,
-        val httpResponseMessage: String = "",
-        val httpResponseHeaders: Map<String, List<String>> = emptyMap<String, List<String>>(),
-        val httpContentLength: Long = 0L,
+        val statusCode: Int = -1,
+        val responseMessage: String = "",
+        val headers: Map<String, List<String>> = emptyMap(),
+        val contentLength: Long = 0L,
         val dataStream: InputStream = ByteArrayInputStream(ByteArray(0))
 ) {
+    @Deprecated(replaceWith = ReplaceWith("contentLength"), message = "http naming is deprecated, use 'contentLength' instead")
+    val httpContentLength get() = contentLength
+
+    @Deprecated(replaceWith = ReplaceWith("responseMessage"), message = "http naming is deprecated, use 'responseMessage' instead")
+    val httpResponseMessage get() = responseMessage
+
+    @Deprecated(replaceWith = ReplaceWith("statusCode"), message = "http naming is deprecated, use 'statusCode' instead")
+    val httpStatusCode get() = statusCode
+
+    @Deprecated(replaceWith = ReplaceWith("headers"), message = "http naming is deprecated, use 'headers' instead")
+    val httpResponseHeaders get() = headers
+
     val data: ByteArray by lazy {
         try {
             dataStream.use { dataStream.readBytes() }
@@ -22,12 +34,12 @@ class Response(
     }
 
     override fun toString(): String = buildString {
-        appendln("<-- $httpStatusCode ($url)")
-        appendln("Response : $httpResponseMessage")
-        appendln("Length : $httpContentLength")
+        appendln("<-- $statusCode ($url)")
+        appendln("Response : $responseMessage")
+        appendln("Length : $contentLength")
         appendln("Body : ${if (data.isNotEmpty()) String(data) else "(empty)"}")
-        appendln("Headers : (${httpResponseHeaders.size})")
-        for ((key, value) in httpResponseHeaders) {
+        appendln("Headers : (${headers.size})")
+        for ((key, value) in headers) {
             appendln("$key : $value")
         }
     }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/deserializers/ByteArrayDeserializer.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/deserializers/ByteArrayDeserializer.kt
@@ -4,7 +4,5 @@ import com.github.kittinunf.fuel.core.Deserializable
 import com.github.kittinunf.fuel.core.Response
 
 class ByteArrayDeserializer : Deserializable<ByteArray> {
-    override fun deserialize(response: Response): ByteArray {
-        return response.data
-    }
+    override fun deserialize(response: Response): ByteArray = response.data
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/deserializers/StringDeserializer.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/deserializers/StringDeserializer.kt
@@ -4,8 +4,6 @@ import com.github.kittinunf.fuel.core.Deserializable
 import com.github.kittinunf.fuel.core.Response
 import java.nio.charset.Charset
 
-class StringDeserializer(val charset: Charset = Charsets.UTF_8) : Deserializable<String> {
-    override fun deserialize(response: Response): String {
-        return String(response.data, charset)
-    }
+class StringDeserializer(private val charset: Charset = Charsets.UTF_8) : Deserializable<String> {
+    override fun deserialize(response: Response): String = String(response.data, charset)
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -10,14 +10,14 @@ class RedirectException : Exception("Redirection fail, not found URL to redirect
 fun redirectResponseInterceptor(manager: FuelManager) =
         { next: (Request, Response) -> Response ->
             { request: Request, response: Response ->
-                if (response.httpStatusCode == HttpsURLConnection.HTTP_MOVED_PERM ||
-                        response.httpStatusCode == HttpsURLConnection.HTTP_MOVED_TEMP ||
-                        response.httpStatusCode == 307   // 307 TEMPORARY REDIRECT - https://httpstatuses.com/307
+                if (response.statusCode == HttpsURLConnection.HTTP_MOVED_PERM ||
+                        response.statusCode == HttpsURLConnection.HTTP_MOVED_TEMP ||
+                        response.statusCode == 307   // 307 TEMPORARY REDIRECT - https://httpstatuses.com/307
                         ) {
-                    val redirectedUrl = response.httpResponseHeaders["Location"]
+                    val redirectedUrl = response.headers["Location"]
                     if (redirectedUrl != null && !redirectedUrl.isEmpty()) {
                         val encoding = Encoding(
-                                httpMethod = request.httpMethod,
+                                httpMethod = request.method,
                                 urlString = try {
                                     URL(redirectedUrl[0]).toString()
                                 } catch (e: MalformedURLException) {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -29,11 +29,7 @@ fun redirectResponseInterceptor(manager: FuelManager) =
                         manager.request(encoding).response().second
                     } else {
                         //error
-                        val error = FuelError().apply {
-                            exception = RedirectException()
-                            errorData = response.data
-                            this.response = response
-                        }
+                        val error = FuelError(RedirectException(), response.data, response)
                         throw error
                     }
                 } else {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -13,19 +13,18 @@ fun redirectResponseInterceptor(manager: FuelManager) =
                 if (response.httpStatusCode == HttpsURLConnection.HTTP_MOVED_PERM ||
                         response.httpStatusCode == HttpsURLConnection.HTTP_MOVED_TEMP ||
                         response.httpStatusCode == 307   // 307 TEMPORARY REDIRECT - https://httpstatuses.com/307
-                   ) {
+                        ) {
                     val redirectedUrl = response.httpResponseHeaders["Location"]
                     if (redirectedUrl != null && !redirectedUrl.isEmpty()) {
-                        val encoding = Encoding().apply {
-                            httpMethod = request.httpMethod
-                            urlString =
-                            try {
-                                URL(redirectedUrl[0]).toString()
-                            } catch (e: MalformedURLException){
-                                // Maybe its a relative url. Use the original for context.
-                                URL(request.url, redirectedUrl[0]).toString()
-                            }
-                        }
+                        val encoding = Encoding(
+                                httpMethod = request.httpMethod,
+                                urlString = try {
+                                    URL(redirectedUrl[0]).toString()
+                                } catch (e: MalformedURLException) {
+                                    // Maybe its a relative url. Use the original for context.
+                                    URL(request.url, redirectedUrl[0]).toString()
+                                }
+                        )
                         manager.request(encoding).response().second
                     } else {
                         //error

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/ValidatorInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/ValidatorInterceptor.kt
@@ -9,11 +9,7 @@ fun validatorResponseInterceptor(validRange: IntRange) =
         { next: (Request, Response) -> Response ->
             { request: Request, response: Response ->
                 if (!validRange.contains(response.httpStatusCode)) {
-                    val error = FuelError().apply {
-                        exception = HttpException(response.httpStatusCode, response.httpResponseMessage)
-                        errorData = response.data
-                        this.response = response
-                    }
+                    val error = FuelError(HttpException(response.httpStatusCode, response.httpResponseMessage), response.data, response)
                     throw error
                 } else {
                     next(request, response)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/ValidatorInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/ValidatorInterceptor.kt
@@ -8,8 +8,8 @@ import com.github.kittinunf.fuel.core.Response
 fun validatorResponseInterceptor(validRange: IntRange) =
         { next: (Request, Response) -> Response ->
             { request: Request, response: Response ->
-                if (!validRange.contains(response.httpStatusCode)) {
-                    val error = FuelError(HttpException(response.httpStatusCode, response.httpResponseMessage), response.data, response)
+                if (!validRange.contains(response.statusCode)) {
+                    val error = FuelError(HttpException(response.statusCode, response.responseMessage), response.data, response)
                     throw error
                 } else {
                     next(request, response)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/AsyncTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/AsyncTaskRequest.kt
@@ -22,6 +22,5 @@ class AsyncTaskRequest(val task: TaskRequest) : TaskRequest(task.request) {
         }
     }
 
-    private fun errorResponse() = Response().apply { url = request.url }
-
+    private fun errorResponse() = Response(request.url)
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/AsyncTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/AsyncTaskRequest.kt
@@ -4,7 +4,6 @@ import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Response
 
 class AsyncTaskRequest(val task: TaskRequest) : TaskRequest(task.request) {
-
     var successCallback: ((Response) -> Unit)? = null
     var failureCallback: ((FuelError, Response) -> Unit)? = null
 
@@ -16,9 +15,7 @@ class AsyncTaskRequest(val task: TaskRequest) : TaskRequest(task.request) {
             failureCallback?.invoke(error, error.response)
             return errorResponse()
         } catch(ex: Exception) {
-            val error = FuelError().apply {
-                exception = ex
-            }
+            val error = FuelError(ex)
             val response = errorResponse()
             failureCallback?.invoke(error, response)
             return response

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/AsyncTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/AsyncTaskRequest.kt
@@ -3,23 +3,22 @@ package com.github.kittinunf.fuel.core.requests
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Response
 
-class AsyncTaskRequest(val task: TaskRequest) : TaskRequest(task.request) {
+internal class AsyncTaskRequest(private val task: TaskRequest) : TaskRequest(task.request) {
     var successCallback: ((Response) -> Unit)? = null
     var failureCallback: ((FuelError, Response) -> Unit)? = null
 
-    override fun call(): Response {
-        return try {
-            val response = task.call()
-            response.apply { successCallback?.invoke(this) }
-        } catch(error: FuelError) {
-            failureCallback?.invoke(error, error.response)
-            return errorResponse()
-        } catch(ex: Exception) {
-            val error = FuelError(ex)
-            val response = errorResponse()
-            failureCallback?.invoke(error, response)
-            return response
+    override fun call(): Response = try {
+        task.call().apply {
+            successCallback?.invoke(this)
         }
+    } catch (error: FuelError) {
+        failureCallback?.invoke(error, error.response)
+        errorResponse()
+    } catch (ex: Exception) {
+        val error = FuelError(ex)
+        val response = errorResponse()
+        failureCallback?.invoke(error, response)
+        response
     }
 
     private fun errorResponse() = Response(request.url)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
@@ -16,7 +16,7 @@ internal class DownloadTaskRequest(request: Request) : TaskRequest(request) {
         val file = destinationCallback(response, request.url)
         val fileOutputStream = FileOutputStream(file)
         response.dataStream.copyTo(fileOutputStream, BUFFER_SIZE) { readBytes ->
-            progressCallback?.invoke(readBytes, response.httpContentLength)
+            progressCallback?.invoke(readBytes, response.contentLength)
         }
         return response
     }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
@@ -3,29 +3,23 @@ package com.github.kittinunf.fuel.core.requests
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.util.copyTo
-import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileOutputStream
-import java.io.InputStream
 import java.net.URL
 
-class DownloadTaskRequest(request: Request) : TaskRequest(request) {
-
-    val BUFFER_SIZE = 1024
-
+internal class DownloadTaskRequest(request: Request) : TaskRequest(request) {
     var progressCallback: ((Long, Long) -> Unit)? = null
     lateinit var destinationCallback: ((Response, URL) -> File)
 
-    lateinit var fileOutputStream: FileOutputStream
-
     override fun call(): Response {
         val response = super.call()
-        val file = destinationCallback.invoke(response, request.url)
-        //file output
-        fileOutputStream = FileOutputStream(file)
+        val file = destinationCallback(response, request.url)
+        val fileOutputStream = FileOutputStream(file)
         response.dataStream.copyTo(fileOutputStream, BUFFER_SIZE) { readBytes ->
-                progressCallback?.invoke(readBytes, response.httpContentLength)
+            progressCallback?.invoke(readBytes, response.httpContentLength)
         }
         return response
     }
 }
+
+private const val BUFFER_SIZE = 1024

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/TaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/TaskRequest.kt
@@ -6,22 +6,18 @@ import com.github.kittinunf.fuel.core.Response
 import java.io.InterruptedIOException
 import java.util.concurrent.Callable
 
-open class TaskRequest(val request: Request) : Callable<Response> {
-
+internal open class TaskRequest(internal val request: Request) : Callable<Response> {
     var interruptCallback: ((Request) -> Unit)? = null
 
-    override fun call(): Response {
-        try {
-            val modifiedRequest = request.requestInterceptor?.invoke(request) ?: request
-            val response = request.client.executeRequest(modifiedRequest)
-            val modifiedResponse = request.responseInterceptor?.invoke(modifiedRequest, response) ?: response
-            return modifiedResponse
-        } catch(error: FuelError) {
-            if (error.exception as? InterruptedIOException != null) {
-                interruptCallback?.invoke(request)
-            }
-            throw error
-        }
-    }
+    override fun call(): Response = try {
+        val modifiedRequest = request.requestInterceptor?.invoke(request) ?: request
+        val response = request.client.executeRequest(modifiedRequest)
 
+        request.responseInterceptor?.invoke(modifiedRequest, response) ?: response
+    } catch (error: FuelError) {
+        if (error.exception as? InterruptedIOException != null) {
+            interruptCallback?.invoke(request)
+        }
+        throw error
+    }
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -3,7 +3,6 @@ package com.github.kittinunf.fuel.core.requests
 import com.github.kittinunf.fuel.core.Blob
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.util.copyTo
-import com.github.kittinunf.fuel.util.toHexString
 import java.io.OutputStream
 import java.net.URL
 import java.net.URLConnection
@@ -68,7 +67,7 @@ class UploadTaskRequest(request: Request) : TaskRequest(request) {
     val BUFFER_SIZE = 1024
 
     val CRLF = "\r\n"
-    val boundary = request.httpHeaders["Content-Type"]?.split("=", limit = 2)?.get(1) ?: System.currentTimeMillis().toHexString()
+    val boundary = request.httpHeaders["Content-Type"]?.split("=", limit = 2)?.get(1) ?: System.currentTimeMillis().toString(16)
 
     var progressCallback: ((Long, Long) -> Unit)? = null
     lateinit var sourceCallback: (Request, URL) -> Iterable<Blob>

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -7,82 +7,86 @@ import java.io.OutputStream
 import java.net.URL
 import java.net.URLConnection
 
-class UploadTaskRequest(request: Request) : TaskRequest(request) {
+internal class UploadTaskRequest(request: Request) : TaskRequest(request) {
+    var progressCallback: ((Long, Long) -> Unit)? = null
+    lateinit var sourceCallback: (Request, URL) -> Iterable<Blob>
 
-    var bodyCallBack = fun (request: Request, outputStream: OutputStream?, totalLength: Long): Long {
-        fun write(str: String): Int {
-            val data = str.toByteArray()
-            outputStream?.write(data)
-            return data.size
-        }
-
+    private var bodyCallBack = fun(request: Request, outputStream: OutputStream?, totalLength: Long): Long {
         var contentLength = 0L
         outputStream.apply {
-            val files = sourceCallback.invoke(request, request.url)
+            val files = sourceCallback(request, request.url)
 
-            files.forEachIndexed { i, blob ->
+            files.forEachIndexed { i, (name, length, inputStream) ->
                 val postFix = if (files.count() == 1) "" else "${i + 1}"
                 val fieldName = request.names.getOrElse(i) { request.name + postFix }
 
                 contentLength += write("--$boundary")
-                contentLength += write(CRLF)
-                contentLength += write("Content-Disposition: form-data; name=\"$fieldName\"; filename=\"${blob.name}\"")
-                contentLength += write(CRLF)
-                contentLength += write("Content-Type: " + request.mediaTypes.getOrElse(i) { guessContentType(blob) })
-                contentLength += write(CRLF)
-                contentLength += write(CRLF)
+                contentLength += writeln()
+                contentLength += write("Content-Disposition: form-data; name=\"$fieldName\"; filename=\"$name\"")
+                contentLength += writeln()
+                contentLength += write("Content-Type: " + request.mediaTypes.getOrElse(i) { guessContentType(name) })
+                contentLength += writeln()
+                contentLength += writeln()
 
                 //input file data
                 if (outputStream != null) {
-                    blob.inputStream().use {
+                    inputStream().use {
                         it.copyTo(outputStream, BUFFER_SIZE) { writtenBytes ->
                             progressCallback?.invoke(contentLength + writtenBytes, totalLength)
                         }
                     }
                 }
-                contentLength += blob.length
-                contentLength += write(CRLF)
+                contentLength += length
+                contentLength += writeln()
             }
 
-            request.parameters.forEach {
+            request.parameters.forEach { (name, data) ->
                 contentLength += write("--$boundary")
-                contentLength += write(CRLF)
-                contentLength += write("Content-Disposition: form-data; name=\"${it.first}\"")
-                contentLength += write(CRLF)
+                contentLength += writeln()
+                contentLength += write("Content-Disposition: form-data; name=\"$name\"")
+                contentLength += writeln()
                 contentLength += write("Content-Type: text/plain")
-                contentLength += write(CRLF)
-                contentLength += write(CRLF)
-                contentLength += write(it.second.toString())
-                contentLength += write(CRLF)
+                contentLength += writeln()
+                contentLength += writeln()
+                contentLength += write(data.toString())
+                contentLength += writeln()
             }
 
             contentLength += write("--$boundary--")
-            contentLength += write(CRLF)
+            contentLength += writeln()
         }
 
         progressCallback?.invoke(contentLength, totalLength)
         return contentLength
     }
 
-    val BUFFER_SIZE = 1024
+    private val boundary = request.httpHeaders["Content-Type"]?.split("=", limit = 2)?.get(1) ?: System.currentTimeMillis().toString(16)
 
-    val CRLF = "\r\n"
-    val boundary = request.httpHeaders["Content-Type"]?.split("=", limit = 2)?.get(1) ?: System.currentTimeMillis().toString(16)
-
-    var progressCallback: ((Long, Long) -> Unit)? = null
-    lateinit var sourceCallback: (Request, URL) -> Iterable<Blob>
-
-    init{
+    init {
         request.bodyCallback = bodyCallBack
     }
-
-    private fun guessContentType(blob: Blob): String {
-        try {
-            return URLConnection.guessContentTypeFromName(blob.name) ?: "application/octet-stream"
-        } catch (ex: NoClassDefFoundError) {
-            // The MimetypesFileTypeMap class doesn't exists on old Android devices.
-            return "application/octet-stream"
-        }
-    }
 }
+
+fun OutputStream?.write(str: String): Int {
+    val data = str.toByteArray()
+    this?.write(data)
+    return data.size
+}
+
+fun OutputStream?.writeln(): Int {
+    this?.write(CRLF)
+    return CRLF.size
+}
+
+private const val BUFFER_SIZE = 1024
+private val CRLF = "\r\n".toByteArray()
+
+private fun guessContentType(name: String): String = try {
+    URLConnection.guessContentTypeFromName(name) ?: "application/octet-stream"
+} catch (ex: NoClassDefFoundError) {
+    // The MimetypesFileTypeMap class doesn't exists on old Android devices.
+    "application/octet-stream"
+}
+
+
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -60,7 +60,7 @@ internal class UploadTaskRequest(request: Request) : TaskRequest(request) {
         return contentLength
     }
 
-    private val boundary = request.httpHeaders["Content-Type"]?.split("=", limit = 2)?.get(1) ?: System.currentTimeMillis().toString(16)
+    private val boundary = request.headers["Content-Type"]?.split("=", limit = 2)?.get(1) ?: System.currentTimeMillis().toString(16)
 
     init {
         request.bodyCallback = bodyCallBack

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/UploadTaskRequest.kt
@@ -87,6 +87,3 @@ private fun guessContentType(name: String): String = try {
     // The MimetypesFileTypeMap class doesn't exists on old Android devices.
     "application/octet-stream"
 }
-
-
-

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -1,7 +1,11 @@
 package com.github.kittinunf.fuel.toolbox
 
 import com.github.kittinunf.fuel.Fuel
-import com.github.kittinunf.fuel.core.*
+import com.github.kittinunf.fuel.core.Method
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.fuel.core.Client
+import com.github.kittinunf.fuel.core.FuelError
 import java.io.BufferedOutputStream
 import java.io.ByteArrayInputStream
 import java.io.IOException

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -40,7 +40,7 @@ internal class HttpClient(private val proxy: Proxy? = null) : Client {
 
             return Response(
                     url = request.url,
-                    httpResponseHeaders = connection.headerFields.filterKeys { it != null },
+                    headers = connection.headerFields.filterKeys { it != null },
                     contentLength = connection.contentLength.toLong(),
                     statusCode = connection.responseCode,
                     responseMessage = connection.responseMessage.orEmpty(),

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -66,11 +66,7 @@ class HttpClient(val proxy: Proxy? = null) : Client {
                 }
             }
         } catch(exception: Exception) {
-            throw FuelError().apply {
-                this.exception = exception
-                this.errorData = response.data
-                this.response = response
-            }
+            throw FuelError(exception, response.data, response)
         } finally {
             //As per Android documentation, a connection that is not explicitly disconnected
             //will be pooled and reused!  So, don't close it as we need inputStream later!

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -21,18 +21,18 @@ internal class HttpClient(private val proxy: Proxy? = null) : Client {
                 readTimeout = Fuel.testConfiguration.coerceTimeoutRead(request.timeoutReadInMillisecond)
                 doInput = true
                 useCaches = false
-                requestMethod = if (request.httpMethod == Method.PATCH) Method.POST.value else request.httpMethod.value
+                requestMethod = if (request.method == Method.PATCH) Method.POST.value else request.method.value
                 instanceFollowRedirects = false
 
-                for ((key, value) in request.httpHeaders) {
+                for ((key, value) in request.headers) {
                     setRequestProperty(key, value)
                 }
 
-                if (request.httpMethod == Method.PATCH) {
+                if (request.method == Method.PATCH) {
                     setRequestProperty("X-HTTP-Method-Override", "PATCH")
                 }
 
-                setDoOutput(connection, request.httpMethod)
+                setDoOutput(connection, request.method)
                 setBodyIfDoOutput(connection, request)
             }
 
@@ -41,9 +41,9 @@ internal class HttpClient(private val proxy: Proxy? = null) : Client {
             return Response(
                     url = request.url,
                     httpResponseHeaders = connection.headerFields.filterKeys { it != null },
-                    httpContentLength = connection.contentLength.toLong(),
-                    httpStatusCode = connection.responseCode,
-                    httpResponseMessage = connection.responseMessage.orEmpty(),
+                    contentLength = connection.contentLength.toLong(),
+                    statusCode = connection.responseCode,
+                    responseMessage = connection.responseMessage.orEmpty(),
                     dataStream = try {
                         val stream = connection.errorStream ?: connection.inputStream
                         if (contentEncoding.compareTo("gzip", true) == 0) GZIPInputStream(stream) else stream

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/Delegates.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/Delegates.kt
@@ -3,7 +3,7 @@ package com.github.kittinunf.fuel.util
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
-fun <T> readWriteLazy(initializer: () -> T): ReadWriteProperty<Any?, T> = ReadWriteLazyVal(initializer)
+internal fun <T> readWriteLazy(initializer: () -> T): ReadWriteProperty<Any?, T> = ReadWriteLazyVal(initializer)
 
 private class ReadWriteLazyVal<T>(private val initializer: () -> T) : ReadWriteProperty<Any?, T> {
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
@@ -39,13 +39,12 @@ interface FuelRouting: Fuel.RequestConvertible {
     override val request: Request
         get() {
             // generate the encoder according provided parameters, headers, path, etc.
-            val encoder = Encoding().apply {
-                this.baseUrlString = basePath
-                this.httpMethod = method
-                this.urlString = path
-                this.parameters = params
-            }
-
+            val encoder = Encoding(
+                    baseUrlString = basePath,
+                    httpMethod = method,
+                    urlString = path,
+                    parameters = params
+            )
             // return the generated encoder with custom header injected
             return encoder.request.header(headers)
         }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/InputStreams.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/InputStreams.kt
@@ -3,7 +3,7 @@ package com.github.kittinunf.fuel.util
 import java.io.InputStream
 import java.io.OutputStream
 
-fun InputStream.copyTo(out: OutputStream, bufferSize: Int = DEFAULT_BUFFER_SIZE, progress: ((Long) -> Unit)?): Long {
+internal fun InputStream.copyTo(out: OutputStream, bufferSize: Int = DEFAULT_BUFFER_SIZE, progress: ((Long) -> Unit)?): Long {
     var bytesCopied = 0L
     val buffer = ByteArray(bufferSize)
     var bytes = read(buffer)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/Longs.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/Longs.kt
@@ -1,3 +1,0 @@
-package com.github.kittinunf.fuel.util
-
-fun Long.toHexString(): String = java.lang.Long.toHexString(this)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/SameThreadExecutorService.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/SameThreadExecutorService.kt
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 /**
  * Executes all submitted tasks directly in the same thread as the caller.
  */
-class SameThreadExecutorService : AbstractExecutorService() {
+internal class SameThreadExecutorService : AbstractExecutorService() {
     //volatile because can be viewed by other threads
     @Volatile private var terminated: Boolean = false
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/SameThreadExecutorService.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/SameThreadExecutorService.kt
@@ -7,7 +7,6 @@ import java.util.concurrent.TimeUnit
  * Executes all submitted tasks directly in the same thread as the caller.
  */
 class SameThreadExecutorService : AbstractExecutorService() {
-
     //volatile because can be viewed by other threads
     @Volatile private var terminated: Boolean = false
 
@@ -15,13 +14,9 @@ class SameThreadExecutorService : AbstractExecutorService() {
         terminated = true
     }
 
-    override fun isShutdown(): Boolean {
-        return terminated
-    }
+    override fun isShutdown(): Boolean = terminated
 
-    override fun isTerminated(): Boolean {
-        return terminated
-    }
+    override fun isTerminated(): Boolean = terminated
 
     @Throws(InterruptedException::class)
     override fun awaitTermination(theTimeout: Long, theUnit: TimeUnit): Boolean {
@@ -29,11 +24,7 @@ class SameThreadExecutorService : AbstractExecutorService() {
         return terminated
     }
 
-    override fun shutdownNow(): List<Runnable> {
-        return emptyList()
-    }
+    override fun shutdownNow(): List<Runnable> = emptyList()
 
-    override fun execute(theCommand: Runnable) {
-        theCommand.run()
-    }
+    override fun execute(theCommand: Runnable) = theCommand.run()
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/TestConfiguration.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/TestConfiguration.kt
@@ -17,4 +17,8 @@ data class TestConfiguration(
         /**
          * If set to true, it will block the thread for every request.
          */
-        var blocking: Boolean = true)
+        var blocking: Boolean = true) {
+
+    fun coerceTimeout(timeout: Int) = this.timeout?.let { if (it == -1) Int.MAX_VALUE else it } ?: timeout
+    fun coerceTimeoutRead(timeout: Int) = this.timeoutRead?.let { if (it == -1) Int.MAX_VALUE else it } ?: timeout
+}

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
@@ -29,11 +29,11 @@ class BlockingRequestTest : BaseTestCase() {
         override val request = createRequest()
 
         fun createRequest(): Request {
-            val encoder = Encoding().apply {
-                httpMethod = method
-                urlString = "http://httpbin.org/$relativePath"
-                parameters = listOf("foo" to "bar")
-            }
+            val encoder = Encoding(
+                    httpMethod = method,
+                    urlString = "http://httpbin.org/$relativePath",
+                    parameters = listOf("foo" to "bar")
+            )
             return encoder.request
         }
     }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
@@ -45,7 +45,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -57,7 +57,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -72,7 +72,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
 
         assertThat(data.get(), containsString(paramKey))
         assertThat(data.get(), containsString(paramValue))
@@ -89,7 +89,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
 
         assertThat(data.get(), containsString(paramKey))
         assertThat(data.get(), containsString(paramValue))
@@ -108,7 +108,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
 
         assertThat(data.get(), containsString(foo))
         assertThat(data.get(), containsString(bar))
@@ -126,7 +126,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
 
         assertThat(data.get(), containsString(paramKey))
         assertThat(data.get(), containsString(paramValue))
@@ -144,7 +144,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
 
         assertThat(data.get(), containsString(paramKey))
         assertThat(data.get(), containsString(paramValue))
@@ -159,7 +159,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
 
         assertThat(data.get(), containsString("user-agent"))
     }
@@ -173,7 +173,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -188,7 +188,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
 
         assertThat(data.get(), containsString(paramKey))
         assertThat(data.get(), containsString(paramValue))
@@ -207,9 +207,9 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
 
-        assertThat(request.httpHeaders[headerKey], isEqualTo(headerValue))
+        assertThat(request.headers[headerKey], isEqualTo(headerValue))
     }
 
     @Test
@@ -229,7 +229,7 @@ class BlockingRequestTest : BaseTestCase() {
         assertThat(data.get(), notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response.statusCode, isEqualTo(statusCode))
     }
 
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/BlockingRequestTest.kt
@@ -13,8 +13,7 @@ import java.net.HttpURLConnection
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class BlockingRequestTest : BaseTestCase() {
-
-    val manager: FuelManager by lazy { FuelManager() }
+    private val manager: FuelManager by lazy { FuelManager() }
 
     enum class HttpsBin(relativePath: String) : Fuel.PathStringConvertible {
         USER_AGENT("user-agent"),
@@ -25,10 +24,10 @@ class BlockingRequestTest : BaseTestCase() {
         override val path = "https://httpbin.org/$relativePath"
     }
 
-    class HttpBinConvertible(val method: Method, val relativePath: String) : Fuel.RequestConvertible {
+    class HttpBinConvertible(val method: Method, private val relativePath: String) : Fuel.RequestConvertible {
         override val request = createRequest()
 
-        fun createRequest(): Request {
+        private fun createRequest(): Request {
             val encoder = Encoding(
                     httpMethod = method,
                     urlString = "http://httpbin.org/$relativePath",
@@ -217,7 +216,7 @@ class BlockingRequestTest : BaseTestCase() {
     fun httpUploadRequestWithParameters() {
         val (request, response, data) =
                 manager.upload(HttpsBin.POST.path, param = listOf("foo" to "bar", "foo1" to "bar1"))
-                        .source { request, url ->
+                        .source { _, _ ->
                             val dir = System.getProperty("user.dir")
                             val currentDir = File(dir, "src/test/assets")
                             File(currentDir, "lorem_ipsum_long.tmp")

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/CustomClientTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/CustomClientTest.kt
@@ -1,10 +1,6 @@
 package com.github.kittinunf.fuel
 
-import com.github.kittinunf.fuel.core.Client
-import com.github.kittinunf.fuel.core.FuelManager
-import com.github.kittinunf.fuel.core.Method
-import com.github.kittinunf.fuel.core.Request
-import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.fuel.core.*
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.notNullValue
 import org.junit.Assert.assertThat
@@ -21,13 +17,10 @@ class CustomClientTest : BaseTestCase() {
 
         FuelManager().apply {
             client = object : Client {
-                override fun executeRequest(request: Request): Response {
-                    return Response().apply {
-                        dataStream = mockJson.inputStream()
-                        httpStatusCode = 200
-                        request.client = client
-                    }
-                }
+                override fun executeRequest(request: Request): Response = Response(
+                        url = request.url,
+                        dataStream = mockJson.inputStream(),
+                        httpStatusCode = 200)
             }
         }
     }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/CustomClientTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/CustomClientTest.kt
@@ -9,8 +9,7 @@ import java.io.File
 import java.nio.charset.Charset
 
 class CustomClientTest : BaseTestCase() {
-
-    val manager: FuelManager by lazy {
+    private val manager: FuelManager by lazy {
         val dir = System.getProperty("user.dir")
         val currentDir = File(dir, "src/test/assets")
         val mockJson = File(currentDir, "mock.json")

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/CustomClientTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/CustomClientTest.kt
@@ -19,7 +19,7 @@ class CustomClientTest : BaseTestCase() {
                 override fun executeRequest(request: Request): Response = Response(
                         url = request.url,
                         dataStream = mockJson.inputStream(),
-                        httpStatusCode = 200)
+                        statusCode = 200)
             }
         }
     }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/EncodingTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/EncodingTest.kt
@@ -10,96 +10,96 @@ class EncodingTest : BaseTestCase() {
 
     @Test
     fun testEncodingNormal() {
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            baseUrlString = "http://www.example.com"
-            urlString = "test"
-            parameters = listOf("a" to "b")
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                baseUrlString = "http://www.example.com",
+                urlString = "test",
+                parameters = listOf("a" to "b")
+        ).request
 
         assertThat(request.url.toString(), isEqualTo("http://www.example.com/test?a=b"))
     }
 
     @Test
     fun testEncodingWithNoParam() {
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            baseUrlString = "http://www.example.com"
-            urlString = "test"
-            parameters = null
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                baseUrlString = "http://www.example.com",
+                urlString = "test",
+                parameters = null
+        ).request
 
         assertThat(request.url.toString(), isEqualTo("http://www.example.com/test"))
     }
 
     @Test
     fun testEncodingWithIntegerParameter() {
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            baseUrlString = "http://www.example.com"
-            urlString = "test"
-            parameters = listOf("foo" to 1)
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                baseUrlString = "http://www.example.com",
+                urlString = "test",
+                parameters = listOf("foo" to 1)
+        ).request
 
         assertThat(request.url.toString(), isEqualTo("http://www.example.com/test?foo=1"))
     }
 
     @Test
     fun testEncodingWithDoubleParameter() {
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            baseUrlString = "http://www.example.com"
-            urlString = "test"
-            parameters = listOf("foo" to 1.1)
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                baseUrlString = "http://www.example.com",
+                urlString = "test",
+                parameters = listOf("foo" to 1.1)
+        ).request
 
         assertThat(request.url.toString(), isEqualTo("http://www.example.com/test?foo=1.1"))
     }
 
     @Test
     fun testEncodingWithBooleanParameter() {
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            baseUrlString = "http://www.example.com"
-            urlString = "test"
-            parameters = listOf("foo" to true)
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                baseUrlString = "http://www.example.com",
+                urlString = "test",
+                parameters = listOf("foo" to true)
+        ).request
 
         assertThat(request.url.toString(), isEqualTo("http://www.example.com/test?foo=true"))
     }
 
     @Test
     fun testEncodingWithNoParamAndNoRelativeUrlString() {
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            baseUrlString = "http://www.example.com/test"
-            urlString = ""
-            parameters = null
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                baseUrlString = "http://www.example.com/test",
+                urlString = "",
+                parameters = null
+        ).request
 
         assertThat(request.url.toString(), isEqualTo("http://www.example.com/test"))
     }
 
     @Test
     fun testEncodingWithJustBaseUrlString() {
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            baseUrlString = "http://www.example.com/test?a=b"
-            urlString = ""
-            parameters = null
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                baseUrlString = "http://www.example.com/test?a=b",
+                urlString = "",
+                parameters = null
+        ).request
 
         assertThat(request.url.toString(), isEqualTo("http://www.example.com/test?a=b"))
     }
 
     @Test
     fun testEncodingWithPercentEscapedCharacterPath() {
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            baseUrlString = "http://www.example.com/U$3|2|\\|@me/P@$\$vv0|2|)"
-            urlString = ""
-            parameters = null
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                baseUrlString = "http://www.example.com/U$3|2|\\|@me/P@$\$vv0|2|)",
+                urlString = "",
+                parameters = null
+        ).request
 
         assertThat(request.url.toString(), isEqualTo("http://www.example.com/U$3%7C2%7C%5C%7C@me/P@$\$vv0%7C2%7C)"))
     }
@@ -107,10 +107,10 @@ class EncodingTest : BaseTestCase() {
     @Test
     fun testEncodingAlreadyEncodedUrl() {
         val supposed = "https://www.example.com/files/%D7%98%D7%A7%D7%A1%D7%98%20%D7%91%D7%A2%D7%91%D7%A8%D7%99%D7%AA%201%203.txt"
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            urlString = supposed
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                urlString = supposed
+        ).request
 
         assertThat(request.url.toString(), isEqualTo(supposed))
     }
@@ -120,11 +120,11 @@ class EncodingTest : BaseTestCase() {
         val hebrewString = "טקסט בעברית 1 3.txt"
         val path = "https://www.example.com/files/" + hebrewString
 
-        val request = Encoding().apply {
-            httpMethod = Method.GET
-            urlString = path
-            parameters = null
-        }.request
+        val request = Encoding(
+                httpMethod = Method.GET,
+                urlString = path,
+                parameters = null
+        ).request
 
         val supposed = "https://www.example.com/files/%D7%98%D7%A7%D7%A1%D7%98%20%D7%91%D7%A2%D7%91%D7%A8%D7%99%D7%AA%201%203.txt"
         assertThat(request.url.toString(), isEqualTo(supposed))

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/ErrorTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/ErrorTest.kt
@@ -10,9 +10,7 @@ import org.junit.Test
 class ErrorTest: BaseTestCase() {
     @Test
     fun testNoMessageException() {
-        val error = FuelError().apply {
-            exception = RuntimeException()
-        }
+        val error = FuelError(RuntimeException())
 
         assertThat(error.toString(), containsString("<no message>"))
         assertThat(error.toString(), not(containsString("null")))
@@ -21,10 +19,7 @@ class ErrorTest: BaseTestCase() {
 
     @Test
     fun testMessageException() {
-        val error = FuelError().apply {
-            exception = RuntimeException("error")
-        }
-
+        val error = FuelError(RuntimeException("error"))
         assertThat(error.toString(), containsString("error"))
         assertThat(error.toString(), not(containsString("<no message>")))
     }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/HttpHeadRequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/HttpHeadRequestTest.kt
@@ -24,7 +24,7 @@ class HttpHeadRequestTest : BaseTestCase() {
             err = resErr
         }
 
-        assertThat(res?.httpStatusCode, isEqualTo(200))
+        assertThat(res?.statusCode, isEqualTo(200))
         assertThat(req, notNullValue())
         assertThat(res, notNullValue())
         assertThat(err, nullValue())

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
@@ -24,7 +24,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }
 
     @Test
@@ -40,7 +40,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }
 
     @Test
@@ -70,7 +70,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
         assertThat(interceptorCalled, isEqualTo(true))
     }
 
@@ -111,7 +111,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
         assertThat(interceptorCalled, isEqualTo(true))
         assertThat(interceptorNotCalled, isEqualTo(true))
     }
@@ -134,7 +134,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }
 
     @Test
@@ -154,7 +154,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_MOVED_TEMP))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_MOVED_TEMP))
     }
 
     @Test
@@ -174,7 +174,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }
 
     @Test
@@ -193,7 +193,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, containsString("\"user-agent\": \"Fuel\""))
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }
 
     @Test
@@ -214,7 +214,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+        assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }
 
     @Test
@@ -232,7 +232,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, notNullValue())
         assertThat(data, nullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(418))
+        assertThat(response.statusCode, isEqualTo(418))
     }
 
     @Test
@@ -249,7 +249,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response.httpStatusCode, isEqualTo(418))
+        assertThat(response.statusCode, isEqualTo(418))
     }
 
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestAuthenticationTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestAuthenticationTest.kt
@@ -39,7 +39,7 @@ class RequestAuthenticationTest : BaseTestCase() {
         assertThat(data, nullValue())
 
         val statusCode = HttpURLConnection.HTTP_UNAUTHORIZED
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -63,7 +63,7 @@ class RequestAuthenticationTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestAuthenticationTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestAuthenticationTest.kt
@@ -9,16 +9,10 @@ import java.net.HttpURLConnection
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class RequestAuthenticationTest : BaseTestCase() {
+    private val user: String = "username"
+    private val password: String = "password"
 
-    val user: String
-    val password: String
-
-    init {
-        user = "username"
-        password = "password"
-    }
-
-    val manager: FuelManager by lazy {
+    private val manager: FuelManager by lazy {
         FuelManager().apply {
             basePath = "http://httpbin.org"
         }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestDownloadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestDownloadTest.kt
@@ -6,6 +6,7 @@ import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
 import org.hamcrest.CoreMatchers.*
 import org.junit.Assert.assertThat
+import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 import java.io.IOException
@@ -13,8 +14,7 @@ import java.net.HttpURLConnection
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class RequestDownloadTest : BaseTestCase() {
-
-    val manager: FuelManager by lazy {
+    private val manager: FuelManager by lazy {
         FuelManager().apply {
             basePath = "http://httpbin.org"
         }
@@ -29,7 +29,7 @@ class RequestDownloadTest : BaseTestCase() {
 
         val numberOfBytes = 32768L
 
-        manager.download("/bytes/$numberOfBytes").destination { response, url ->
+        manager.download("/bytes/$numberOfBytes").destination { _, _ ->
             val f = File.createTempFile(numberOfBytes.toString(), null)
             println(f.absolutePath)
             f
@@ -61,7 +61,7 @@ class RequestDownloadTest : BaseTestCase() {
         var total = -1L
 
         val numberOfBytes = 1048576L
-        manager.download("/bytes/$numberOfBytes").destination { response, url ->
+        manager.download("/bytes/$numberOfBytes").destination { _, _ ->
             val f = File.createTempFile(numberOfBytes.toString(), null)
             println(f.absolutePath)
             f
@@ -95,11 +95,11 @@ class RequestDownloadTest : BaseTestCase() {
         var error: FuelError? = null
 
         val numberOfBytes = 131072
-        manager.download("/byte/$numberOfBytes").destination { response, url ->
+        manager.download("/byte/$numberOfBytes").destination { _, _ ->
             val f = File.createTempFile(numberOfBytes.toString(), null)
             println(f.absolutePath)
             f
-        }.progress { readBytes, totalBytes ->
+        }.progress { _, _ ->
 
         }.responseString { req, res, result ->
             request = req
@@ -126,10 +126,10 @@ class RequestDownloadTest : BaseTestCase() {
         var error: FuelError? = null
 
         val numberOfBytes = 131072
-        manager.download("/bytes/$numberOfBytes").destination { response, url ->
+        manager.download("/bytes/$numberOfBytes").destination { _, _ ->
             val dir = System.getProperty("user.dir")
             File.createTempFile("not_found_file", null, File(dir, "not-a-folder"))
-        }.progress { readBytes, totalBytes ->
+        }.progress { _, _ ->
 
         }.responseString { req, res, result ->
             request = req
@@ -160,7 +160,7 @@ class RequestDownloadTest : BaseTestCase() {
         var total = -1L
         var lastPercent = 0L
 
-        manager.download("http://speedtest.tele2.net/100MB.zip").destination { response, url ->
+        manager.download("http://speedtest.tele2.net/100MB.zip").destination { _, _ ->
             val f = File.createTempFile("100MB.zip", null)
             println(f.absolutePath)
             f

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestDownloadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestDownloadTest.kt
@@ -6,7 +6,6 @@ import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
 import org.hamcrest.CoreMatchers.*
 import org.junit.Assert.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 import java.io.IOException
@@ -47,7 +46,7 @@ class RequestDownloadTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -84,7 +83,7 @@ class RequestDownloadTest : BaseTestCase() {
 
         assertThat("read bytes and total bytes should be equal", read == total && read != -1L && total != -1L, isEqualTo(true))
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -115,7 +114,7 @@ class RequestDownloadTest : BaseTestCase() {
         assertThat(data, nullValue())
 
         val statusCode = HttpURLConnection.HTTP_NOT_FOUND
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -146,7 +145,7 @@ class RequestDownloadTest : BaseTestCase() {
 
         val statusCode = -1
         assertThat(error?.exception as IOException, isA(IOException::class.java))
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -187,7 +186,7 @@ class RequestDownloadTest : BaseTestCase() {
 
         assertThat("read bytes and total bytes should be equal", read == total && read != -1L && total != -1L, isEqualTo(true))
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestHandlerTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestHandlerTest.kt
@@ -46,7 +46,7 @@ class RequestHandlerTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(res?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(res?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -76,7 +76,7 @@ class RequestHandlerTest : BaseTestCase() {
         assertThat(data, nullValue())
 
         val statusCode = HttpURLConnection.HTTP_NOT_FOUND
-        assertThat(res?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(res?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -109,7 +109,7 @@ class RequestHandlerTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(res?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(res?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString(paramKey))
         assertThat(string, containsString(paramValue))

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestHeaderTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestHeaderTest.kt
@@ -39,7 +39,7 @@ class RequestHeaderTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         val string = String(data as ByteArray)
         assertThat(string, containsString(headerKey))

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestHeaderTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestHeaderTest.kt
@@ -8,8 +8,7 @@ import java.net.HttpURLConnection
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class RequestHeaderTest : BaseTestCase() {
-
-    val manager: FuelManager by lazy {
+    private val manager: FuelManager by lazy {
         FuelManager().apply {
             basePath = "http://httpbin.org"
         }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestObjectTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestObjectTest.kt
@@ -19,17 +19,13 @@ class RequestObjectTest : BaseTestCase() {
     //Deserializer
     class HttpBinUserAgentModelDeserializer : ResponseDeserializable<HttpBinUserAgentModel> {
 
-        override fun deserialize(content: String): HttpBinUserAgentModel {
-            return HttpBinUserAgentModel(content)
-        }
+        override fun deserialize(content: String): HttpBinUserAgentModel = HttpBinUserAgentModel(content)
 
     }
 
     class HttpBinMalformedDeserializer : ResponseDeserializable<HttpBinUserAgentModel> {
 
-        override fun deserialize(reader: Reader): HttpBinUserAgentModel {
-            throw IllegalStateException("Malformed data")
-        }
+        override fun deserialize(reader: Reader): HttpBinUserAgentModel = throw IllegalStateException("Malformed data")
 
     }
 

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestPathStringConvertibleExtensionTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestPathStringConvertibleExtensionTest.kt
@@ -12,7 +12,6 @@ import java.net.HttpURLConnection
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
-
     init {
         FuelManager.instance.basePath = "https://httpbin.org"
     }
@@ -182,7 +181,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
-        HttpsBin.UPLOAD.httpUpload().source { request, url ->
+        HttpsBin.UPLOAD.httpUpload().source { _, _ ->
             val dir = System.getProperty("user.dir")
             val currentDir = File(dir, "src/test/assets")
             File(currentDir, "lorem_ipsum_long.tmp")
@@ -211,8 +210,8 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
-        HttpsBin.DOWNLOAD.httpDownload().destination { response, url ->
-            File.createTempFile(123456.toString(), null)
+        HttpsBin.DOWNLOAD.httpDownload().destination { _, _ ->
+            File.createTempFile("123456", null)
         }.responseString { req, res, result ->
             request = req
             response = res

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestPathStringConvertibleExtensionTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestPathStringConvertibleExtensionTest.kt
@@ -55,7 +55,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -82,7 +82,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString("https"))
     }
@@ -111,7 +111,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString("https"))
     }
@@ -140,7 +140,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString("https"))
     }
@@ -169,7 +169,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString("https"))
     }
@@ -200,7 +200,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -227,7 +227,7 @@ class RequestPathStringConvertibleExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestSharedInstanceTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestSharedInstanceTest.kt
@@ -9,7 +9,6 @@ import java.net.HttpURLConnection
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class RequestSharedInstanceTest : BaseTestCase() {
-
     init {
         FuelManager.instance.basePath = "https://httpbin.org"
         FuelManager.instance.baseHeaders = mapOf("foo" to "bar")
@@ -23,10 +22,10 @@ class RequestSharedInstanceTest : BaseTestCase() {
         DELETE("delete")
     }
 
-    class HttpBinConvertible(val method: Method, val relativePath: String) : Fuel.RequestConvertible {
+    class HttpBinConvertible(val method: Method, private val relativePath: String) : Fuel.RequestConvertible {
         override val request = createRequest()
 
-        fun createRequest(): Request {
+        private fun createRequest(): Request {
             val encoder = Encoding(
                     httpMethod = method,
                     urlString = "https://httpbin.org$relativePath",
@@ -398,7 +397,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         var read = -1L
         var total = -1L
 
-        Fuel.upload("/post").source { request, url ->
+        Fuel.upload("/post").source { _, _ ->
             val dir = System.getProperty("user.dir")
             File(dir, "src/test/assets/lorem_ipsum_long.tmp")
         }.progress { readBytes, totalBytes ->
@@ -435,7 +434,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         var total = -1L
 
         val numberOfBytes = 1048576
-        Fuel.download("/bytes/$numberOfBytes").destination { response, url ->
+        Fuel.download("/bytes/$numberOfBytes").destination { _, _ ->
             File.createTempFile(numberOfBytes.toString(), null)
         }.progress { readBytes, totalBytes ->
             read = readBytes

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestSharedInstanceTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestSharedInstanceTest.kt
@@ -57,7 +57,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         val string = data as String
 
@@ -93,7 +93,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string.toLowerCase(), containsString("foo"))
         assertThat(string.toLowerCase(), containsString("bar"))
@@ -127,7 +127,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string.toLowerCase(), containsString("foo"))
         assertThat(string.toLowerCase(), containsString("bar"))
@@ -161,7 +161,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string.toLowerCase(), containsString("foo"))
         assertThat(string.toLowerCase(), containsString("bar"))
@@ -195,7 +195,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString("origin"))
     }
@@ -224,7 +224,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString("https"))
     }
@@ -253,7 +253,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString("https"))
     }
@@ -282,7 +282,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString("https"))
     }
@@ -309,7 +309,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -334,7 +334,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -359,7 +359,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -384,7 +384,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -418,7 +418,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(read == total && read != -1L && total != -1L, isEqualTo(true))
     }
@@ -453,7 +453,7 @@ class RequestSharedInstanceTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(read, isEqualTo(total))
     }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestSharedInstanceTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestSharedInstanceTest.kt
@@ -27,11 +27,11 @@ class RequestSharedInstanceTest : BaseTestCase() {
         override val request = createRequest()
 
         fun createRequest(): Request {
-            val encoder = Encoding().apply {
-                httpMethod = method
-                urlString = "https://httpbin.org$relativePath"
-                parameters = listOf("foo" to "bar")
-            }
+            val encoder = Encoding(
+                    httpMethod = method,
+                    urlString = "https://httpbin.org$relativePath",
+                    parameters = listOf("foo" to "bar")
+            )
             return encoder.request
         }
     }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestStringExtensionTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestStringExtensionTest.kt
@@ -14,7 +14,6 @@ import java.net.HttpURLConnection
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class RequestStringExtensionTest : BaseTestCase() {
-
     init {
         FuelManager.instance.basePath = "https://httpbin.org"
         FuelManager.instance.baseHeaders = mapOf("foo" to "bar")
@@ -150,7 +149,7 @@ class RequestStringExtensionTest : BaseTestCase() {
 
         val numberOfBytes = 32768L
 
-        "/bytes/$numberOfBytes".httpDownload().destination { response, url ->
+        "/bytes/$numberOfBytes".httpDownload().destination { _, _ ->
             val f = File.createTempFile(numberOfBytes.toString(), null)
             println(f.absolutePath)
             f
@@ -178,7 +177,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
-        "/put".httpUpload(Method.PUT).source { request, url ->
+        "/put".httpUpload(Method.PUT).source { _, _ ->
             val dir = System.getProperty("user.dir")
             val currentDir = File(dir, "src/test/assets")
             File(currentDir, "lorem_ipsum_long.tmp")
@@ -206,7 +205,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
-        "/post".httpUpload().source { request, url ->
+        "/post".httpUpload().source { _, _ ->
             val dir = System.getProperty("user.dir")
             val currentDir = File(dir, "src/test/assets")
             File(currentDir, "lorem_ipsum_long.tmp")

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestStringExtensionTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestStringExtensionTest.kt
@@ -41,7 +41,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -65,7 +65,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -89,7 +89,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -113,7 +113,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -137,7 +137,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -167,7 +167,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -195,7 +195,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -223,7 +223,7 @@ class RequestStringExtensionTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -83,7 +83,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -108,7 +108,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -138,7 +138,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString(paramKey))
         assertThat(string, containsString(paramValue))
@@ -171,7 +171,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString(paramKey))
         assertThat(string, containsString(paramValue))
@@ -205,7 +205,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString(foo))
         assertThat(string, containsString(bar))
@@ -238,7 +238,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString(paramKey))
         assertThat(string, containsString(paramValue))
@@ -272,7 +272,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString(paramKey))
         assertThat(string, containsString(paramValue))
@@ -305,7 +305,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString(paramKey))
         assertThat(string, containsString(paramValue))
@@ -338,7 +338,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, equalTo(""))
     }
@@ -370,7 +370,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, equalTo(""))
     }
@@ -399,7 +399,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString("user-agent"))
     }
@@ -428,7 +428,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -458,7 +458,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -487,7 +487,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(string, containsString(paramKey))
         assertThat(string, containsString(paramValue))

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -13,8 +13,7 @@ import javax.net.ssl.X509TrustManager
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class RequestTest : BaseTestCase() {
-
-    val manager: FuelManager by lazy { FuelManager() }
+    private val manager: FuelManager by lazy { FuelManager() }
 
     enum class HttpsBin(relativePath: String) : Fuel.PathStringConvertible {
         USER_AGENT("user-agent"),
@@ -32,10 +31,10 @@ class RequestTest : BaseTestCase() {
         override val path = "http://mockbin.org/request/$path"
     }
 
-    class HttpBinConvertible(val method: Method, val relativePath: String) : Fuel.RequestConvertible {
+    class HttpBinConvertible(val method: Method, private val relativePath: String) : Fuel.RequestConvertible {
         override val request = createRequest()
 
-        fun createRequest(): Request {
+        private fun createRequest(): Request {
             val encoder = Encoding(
                     httpMethod = method,
                     urlString = "http://httpbin.org/$relativePath",
@@ -501,7 +500,7 @@ class RequestTest : BaseTestCase() {
             var data: Any? = null
             var error: FuelError? = null
 
-            val request = manager.request(Method.GET, "http://httpbin.org/stream-bytes/4194304").responseString { req, res, result ->
+            val request = manager.request(Method.GET, "http://httpbin.org/stream-bytes/4194304").responseString { _, res, result ->
                 response = res
 
                 val (d, err) = result

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -1,11 +1,6 @@
 package com.github.kittinunf.fuel
 
-import com.github.kittinunf.fuel.core.Encoding
-import com.github.kittinunf.fuel.core.FuelError
-import com.github.kittinunf.fuel.core.FuelManager
-import com.github.kittinunf.fuel.core.Method
-import com.github.kittinunf.fuel.core.Request
-import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.fuel.core.*
 import org.hamcrest.CoreMatchers.*
 import org.junit.Assert.assertThat
 import org.junit.Test
@@ -41,11 +36,11 @@ class RequestTest : BaseTestCase() {
         override val request = createRequest()
 
         fun createRequest(): Request {
-            val encoder = Encoding().apply {
-                httpMethod = method
-                urlString = "http://httpbin.org/$relativePath"
-                parameters = listOf("foo" to "bar")
-            }
+            val encoder = Encoding(
+                    httpMethod = method,
+                    urlString = "http://httpbin.org/$relativePath",
+                    parameters = listOf("foo" to "bar")
+            )
             return encoder.request
         }
     }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
@@ -10,14 +10,13 @@ import java.net.HttpURLConnection
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class RequestUploadTest : BaseTestCase() {
-
-    val manager: FuelManager by lazy {
+    private val manager: FuelManager by lazy {
         FuelManager().apply {
             basePath = "http://httpbin.org"
         }
     }
 
-    val currentDir: File by lazy {
+    private val currentDir: File by lazy {
         val dir = System.getProperty("user.dir")
         File(dir, "src/test/assets")
     }
@@ -29,7 +28,7 @@ class RequestUploadTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
-        manager.upload("/post").source { request, url ->
+        manager.upload("/post").source { _, _ ->
             File(currentDir, "lorem_ipsum_short.tmp")
         }.responseString { req, res, result ->
             request = req
@@ -56,7 +55,7 @@ class RequestUploadTest : BaseTestCase() {
         var error: FuelError? = null
 
         manager.upload("/post", param = listOf("foo" to "bar"))
-                .source { request, url ->
+                .source { _, _ ->
                     File(currentDir, "lorem_ipsum_short.tmp")
                 }
                 .name { "file-name" }
@@ -85,7 +84,7 @@ class RequestUploadTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
-        manager.upload("/put", Method.PUT).source { request, url ->
+        manager.upload("/put", Method.PUT).source { _, _ ->
             File(currentDir, "lorem_ipsum_long.tmp")
         }.responseString { req, res, result ->
             request = req
@@ -114,7 +113,7 @@ class RequestUploadTest : BaseTestCase() {
         var read = -1L
         var total = -1L
 
-        manager.upload("/post").source { request, url ->
+        manager.upload("/post").source { _, _ ->
             File(currentDir, "lorem_ipsum_long.tmp")
         }.progress { readBytes, totalBytes ->
             read = readBytes
@@ -146,9 +145,9 @@ class RequestUploadTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
-        manager.upload("/pos").source { request, url ->
+        manager.upload("/pos").source { _, _ ->
             File(currentDir, "lorem_ipsum_short.tmp")
-        }.progress { readBytes, totalBytes ->
+        }.progress { _, _ ->
 
         }.responseString { req, res, result ->
             request = req
@@ -174,9 +173,9 @@ class RequestUploadTest : BaseTestCase() {
         var data: Any? = null
         var error: FuelError? = null
 
-        manager.upload("/post").source { request, url ->
+        manager.upload("/post").source { _, _ ->
             File(currentDir, "not_found_file.tmp")
-        }.progress { readBytes, totalBytes ->
+        }.progress { _, _ ->
 
         }.responseString { req, res, result ->
             request = req
@@ -205,7 +204,7 @@ class RequestUploadTest : BaseTestCase() {
         var error: FuelError? = null
 
         manager.upload("/post", param = listOf("foo" to "bar"))
-                .sources { request, url ->
+                .sources { _, _ ->
                     listOf(File(currentDir, "lorem_ipsum_short.tmp"),
                             File(currentDir, "lorem_ipsum_long.tmp"))
                 }
@@ -240,7 +239,7 @@ class RequestUploadTest : BaseTestCase() {
         var error: FuelError? = null
 
         manager.upload("/post", param = listOf("foo" to "bar"))
-                .dataParts { request, url ->
+                .dataParts { _, _ ->
                     listOf(
                             DataPart(File(currentDir, "lorem_ipsum_short.tmp"), type = "image/jpeg"),
                             DataPart(File(currentDir, "lorem_ipsum_long.tmp"), name = "second-file", type = "image/jpeg")
@@ -280,8 +279,8 @@ class RequestUploadTest : BaseTestCase() {
 
         manager.upload("/post", param = listOf("foo" to "bar"))
 
-                .blob { request, url ->
-                    request.name = "coolblob"
+                .blob { r, _ ->
+                    r.name = "coolblob"
                     Blob(inputStream = { file.inputStream() }, length = file.length(), name = file.name)
                 }
                 .responseString { req, res, result ->

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestUploadTest.kt
@@ -44,7 +44,7 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -74,7 +74,7 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -100,7 +100,7 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -133,7 +133,7 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
 
         assertThat(read == total && read != -1L && total != -1L, isEqualTo(true))
     }
@@ -163,7 +163,7 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(data, nullValue())
 
         val statusCode = HttpURLConnection.HTTP_NOT_FOUND
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -193,7 +193,7 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(error?.exception as FileNotFoundException, isA(FileNotFoundException::class.java))
 
         val statusCode = -1
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -228,7 +228,7 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(string, containsString("file-name2"))
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -264,7 +264,7 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(string, containsString("second-file"))
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 
     @Test
@@ -301,6 +301,6 @@ class RequestUploadTest : BaseTestCase() {
         assertThat(string, containsString("coolblob"))
 
         val statusCode = HttpURLConnection.HTTP_OK
-        assertThat(response?.httpStatusCode, isEqualTo(statusCode))
+        assertThat(response?.statusCode, isEqualTo(statusCode))
     }
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestValidationTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestValidationTest.kt
@@ -42,7 +42,7 @@ class RequestValidationTest : BaseTestCase() {
         assertThat(error?.errorData, notNullValue())
         assertThat(data, nullValue())
 
-        assertThat(response?.httpStatusCode, isEqualTo(preDefinedStatusCode))
+        assertThat(response?.statusCode, isEqualTo(preDefinedStatusCode))
     }
 
     @Test
@@ -72,7 +72,7 @@ class RequestValidationTest : BaseTestCase() {
         assertThat(error, notNullValue())
         assertThat(data, nullValue())
 
-        assertThat(response?.httpStatusCode, isEqualTo(preDefinedStatusCode))
+        assertThat(response?.statusCode, isEqualTo(preDefinedStatusCode))
     }
 
     @Test
@@ -106,7 +106,7 @@ class RequestValidationTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
 
-        assertThat(response?.httpStatusCode, isEqualTo(preDefinedStatusCode))
+        assertThat(response?.statusCode, isEqualTo(preDefinedStatusCode))
     }
 
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestValidationTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestValidationTest.kt
@@ -11,8 +11,7 @@ import org.junit.Test
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class RequestValidationTest : BaseTestCase() {
-
-    val manager: FuelManager by lazy {
+    private val manager: FuelManager by lazy {
         FuelManager().apply {
             basePath = "http://httpbin.org"
         }


### PR DESCRIPTION
When I tried (and failed) to convert Fuel to a multi-platform project, I've noticed that Fuel codebase needs a refactoring for two goals: 
* Make the code more Kotlin (primary constructors instead of `lateinit`s, use new methods from 1.1 instead of calling Java...)
* Hide Java implementation details out of the public interface

This refactoring attempt tries to hide the Java impl details when it is possible to do it without losing features. However the library is still Java library, and more step has to be taken to make it possible to use Fuel in multi platforms.