### PR TITLE
UrlEncode POST parameters

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -1,7 +1,11 @@
 package com.github.kittinunf.fuel.core
 
 import com.github.kittinunf.fuel.Fuel
-import java.net.*
+import java.net.MalformedURLException
+import java.net.URI
+import java.net.URISyntaxException
+import java.net.URL
+import java.net.URLEncoder
 
 class Encoding(val httpMethod: Method,
                val urlString: String,
@@ -70,7 +74,8 @@ class Encoding(val httpMethod: Method,
 
     private fun queryFromParameters(params: List<Pair<String, Any?>>?): String = params.orEmpty()
             .filterNot { it.second == null }
-            .joinToString("&") { "${URLEncoder.encode(it.first,"UTF-8")}=${URLEncoder.encode("${it.second}","UTF-8")}"}
+            .map { (key, value) ->  URLEncoder.encode(key, "UTF-8") to URLEncoder.encode("$value", "UTF-8") }
+            .joinToString("&") { (key, value) -> "$key=$value" }
 
     private val defaultHeaders = mapOf("Accept-Encoding" to "compress;q=0.5, gzip;q=1.0")
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -1,10 +1,7 @@
 package com.github.kittinunf.fuel.core
 
 import com.github.kittinunf.fuel.Fuel
-import java.net.MalformedURLException
-import java.net.URI
-import java.net.URISyntaxException
-import java.net.URL
+import java.net.*
 
 class Encoding(val httpMethod: Method,
                val urlString: String,
@@ -73,7 +70,7 @@ class Encoding(val httpMethod: Method,
 
     private fun queryFromParameters(params: List<Pair<String, Any?>>?): String = params.orEmpty()
             .filterNot { it.second == null }
-            .joinToString("&") { "${it.first}=${it.second}" }
+            .joinToString("&") { "${URLEncoder.encode(it.first,"UTF-8")}=${URLEncoder.encode("${it.second}","UTF-8")}"}
 
     private val defaultHeaders = mapOf("Accept-Encoding" to "compress;q=0.5, gzip;q=1.0")
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/EncodingTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/EncodingTest.kt
@@ -4,6 +4,7 @@ import com.github.kittinunf.fuel.core.Encoding
 import com.github.kittinunf.fuel.core.Method
 import org.junit.Assert.assertThat
 import org.junit.Test
+import java.io.ByteArrayOutputStream
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class EncodingTest : BaseTestCase() {
@@ -128,6 +129,44 @@ class EncodingTest : BaseTestCase() {
 
         val supposed = "https://www.example.com/files/%D7%98%D7%A7%D7%A1%D7%98%20%D7%91%D7%A2%D7%91%D7%A8%D7%99%D7%AA%201%203.txt"
         assertThat(request.url.toString(), isEqualTo(supposed))
+    }
+
+    @Test
+    fun testPostRequestEncodingWithoutReservedCharacters() {
+        val path = "https://www.example.com/files"
+        val parameters = listOf("param1" to "value1", "param2" to "value2")
+        val request = Encoding(
+                httpMethod = Method.POST,
+                urlString = path,
+                parameters = parameters
+        ).request
+
+        val body = ByteArrayOutputStream().apply {
+            request.bodyCallback?.invoke(request, this, 0)
+        }.toByteArray()
+
+        val bodyString = String(body)
+        print(bodyString)
+        assertThat(bodyString, isEqualTo("param1=value1&param2=value2"))
+    }
+
+    @Test
+    fun testPostRequestEncodingWithReservedCharacters() {
+        val path = "https://www.example.com/files"
+        val parameters = listOf("param1" to "val+ue", "param2" to "val ue",
+                "param3" to "val!ue" ,"param4" to ":/?#[]@$&'()*+,;= ")
+        val request = Encoding(
+                httpMethod = Method.POST,
+                urlString = path,
+                parameters = parameters
+        ).request
+
+        val body = ByteArrayOutputStream().apply {
+            request.bodyCallback?.invoke(request, this, 0)
+        }.toByteArray()
+
+        val bodyString = String(body)
+        assertThat(bodyString, isEqualTo("param1=val%2Bue&param2=val+ue&param3=val%21ue&param4=%3A%2F%3F%23%5B%5D%40%24%26%27%28%29*%2B%2C%3B%3D+"))
     }
 
 }


### PR DESCRIPTION
Parameters of post request were not urlencoded before writing them into the body. Which led to incorrect results on server side because reserved characters were not in %-format!

Now parameter keys and values are encoded before joining them to parameter string.

fixes: #249
