### PR TITLE
DownloadTaskRequest: Properly close the FileOutputStream

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
@@ -14,11 +14,11 @@ internal class DownloadTaskRequest(request: Request) : TaskRequest(request) {
     override fun call(): Response {
         val response = super.call()
         val file = destinationCallback(response, request.url)
-        val fileOutputStream = FileOutputStream(file)
-        response.dataStream.copyTo(fileOutputStream, BUFFER_SIZE) { readBytes ->
-            progressCallback?.invoke(readBytes, response.contentLength)
+        FileOutputStream(file).use {
+            response.dataStream.copyTo(it, BUFFER_SIZE) { readBytes ->
+                progressCallback?.invoke(readBytes, response.contentLength)
+            }
         }
-        fileOutputStream.close()
         return response
     }
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DownloadTaskRequest.kt
@@ -18,6 +18,7 @@ internal class DownloadTaskRequest(request: Request) : TaskRequest(request) {
         response.dataStream.copyTo(fileOutputStream, BUFFER_SIZE) { readBytes ->
             progressCallback?.invoke(readBytes, response.contentLength)
         }
+        fileOutputStream.close()
         return response
     }
 }


### PR DESCRIPTION
Otherwise downloaded files stay locked and cannot e.g. be deleted on
Windows until the JVM shuts down.