### PR TITLE
Pass the expected object type through

### DIFF
--- a/fuel-gson/src/main/kotlin/com/github/kittinunf/fuel/gson/FuelGson.kt
+++ b/fuel-gson/src/main/kotlin/com/github/kittinunf/fuel/gson/FuelGson.kt
@@ -16,7 +16,7 @@ inline fun <reified T : Any> Request.responseObject(noinline handler: (Request, 
 
 inline fun <reified T : Any> Request.responseObject(handler: Handler<T>) = response(gsonDeserializerOf(), handler)
 
-inline fun <reified T : Any> Request.responseObject() = response(gsonDeserializerOf())
+inline fun <reified T : Any> Request.responseObject() = response(gsonDeserializerOf<T>())
 
 inline fun <reified T : Any> gsonDeserializerOf() = object : ResponseDeserializable<T> {
     override fun deserialize(reader: Reader): T = Gson().fromJson<T>(reader, object : TypeToken<T>() {}.type)

--- a/fuel-gson/src/test/kotlin/com/github/kittinunf/fuel/FuelGsonTest.kt
+++ b/fuel-gson/src/test/kotlin/com/github/kittinunf/fuel/FuelGsonTest.kt
@@ -102,6 +102,7 @@ class FuelGsonTest {
     fun gsonTestResponseSyncObject() {
         val triple = Fuel.get("/user-agent").responseObject<HttpBinUserAgentModel>()
         assertThat(triple.third.component1(), notNullValue())
+        assertThat(triple.third.component1(), instanceOf(HttpBinUserAgentModel::class.java))
     }
 
     @Test


### PR DESCRIPTION
Ensure that the response we get back from `responseObject` matches the type we expect.

At the moment any call to `responseObject()` (doesn't matter if we use `reponseObject<String>()`) ends with a `Result<Any, FuelError>`.