### PR TITLE
Also check for lowercase `location` header on redirect

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -14,7 +14,7 @@ fun redirectResponseInterceptor(manager: FuelManager) =
                         response.statusCode == HttpsURLConnection.HTTP_MOVED_TEMP ||
                         response.statusCode == 307   // 307 TEMPORARY REDIRECT - https://httpstatuses.com/307
                         ) {
-                    val redirectedUrl? = response.headers.containsKey("Location") ? response.headers["Location"] : response.headers["location"]
+                    val redirectedUrl = response.headers["Location"] ?: response.headers["location"]
                     if (redirectedUrl != null && !redirectedUrl.isEmpty()) {
                         val encoding = Encoding(
                                 httpMethod = request.method,

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -14,7 +14,7 @@ fun redirectResponseInterceptor(manager: FuelManager) =
                         response.statusCode == HttpsURLConnection.HTTP_MOVED_TEMP ||
                         response.statusCode == 307   // 307 TEMPORARY REDIRECT - https://httpstatuses.com/307
                         ) {
-                    val redirectedUrl = response.headers["Location"]
+                    val redirectedUrl? = response.headers.containsKey("Location") ? response.headers["Location"] : response.headers["location"]
                     if (redirectedUrl != null && !redirectedUrl.isEmpty()) {
                         val encoding = Encoding(
                                 httpMethod = request.method,


### PR DESCRIPTION
Fixes https://github.com/kittinunf/Fuel/issues/279

When there is a redirect status, fuel will first detect the default `Location` header. If it is not present, it will try to use the `location` header.

I looked into creating a test for this, but I did not see a simple way to make https://httpbin.org/ return a redirect with a custom header.