### PR TITLE
Fix cUrlString() format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
 
         classpath 'com.novoda:bintray-release:0.7.0'

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -246,22 +246,22 @@ class Request(
 
         //method
         if (method != Method.GET) {
-            append("-X $method")
+            append(" -X $method")
         }
 
         //body
         val escapedBody = String(getHttpBody()).replace("\"", "\\\"")
         if (escapedBody.isNotEmpty()) {
-            append("-d \"$escapedBody\"")
+            append(" -d \"$escapedBody\"")
         }
 
         //headers
         for ((key, value) in headers) {
-            append("-H \"$key:$value\"")
+            append(" -H \"$key:$value\"")
         }
 
         //url
-        append("\"$url\"")
+        append(" $url")
     }
 
     //byte array

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -5,6 +5,7 @@ import org.hamcrest.CoreMatchers.*
 import org.junit.Assert.assertThat
 import org.junit.Test
 import java.net.HttpURLConnection
+import java.net.URL
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
@@ -515,6 +516,28 @@ class RequestTest : BaseTestCase() {
             assertThat(data, nullValue())
             assertThat(error, nullValue())
         }
+    }
+
+    @Test
+    fun httpGetCurlString() {
+        val request = Request(method = Method.GET,
+                path = "",
+                url = URL("http://httpbin.org/get"),
+                headers = mutableMapOf("Authentication" to "Bearer xxx"),
+                parameters = listOf("foo" to "xxx"))
+
+        assertThat(request.cUrlString(), isEqualTo("$ curl -i -H \"Authentication:Bearer xxx\" http://httpbin.org/get"))
+    }
+
+    @Test
+    fun httpPostCurlString() {
+        val request = Request(method = Method.POST,
+                path = "",
+                url = URL("http://httpbin.org/post"),
+                headers = mutableMapOf("Authentication" to "Bearer xxx"),
+                parameters = listOf("foo" to "xxx"))
+
+        assertThat(request.cUrlString(), isEqualTo("$ curl -i -X POST -H \"Authentication:Bearer xxx\" http://httpbin.org/post"))
     }
 }
 


### PR DESCRIPTION
This PR fixed cUrl string format in issue #281