### PR TITLE
Add response.guessContentType() and improve .toString()

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
@@ -34,22 +34,15 @@ class Response(
         }
     }
 
-//    override fun toString(): String = buildString {
-//        appendln("<-- $statusCode ($url)")
-//        appendln("Response : $responseMessage")
-//        appendln("Length : $contentLength")
-//        appendln("Body : ${if (data.isNotEmpty()) String(data) else "(empty)"}")
-//        appendln("Headers : (${headers.size})")
-//        for ((key, value) in headers) {
-//            appendln("$key : $value")
-//        }
-//    }
-
     override  fun toString(): String {
         var dataString = "(empty)"
         val contentType = guessContentType()
-        if (contentType.isNotEmpty() && !contentType.contains("text/")) {
-            dataString = "${data.size} bytes of ${guessContentType()}"
+
+        if (contentType.isNotEmpty() &&
+                (contentType.contains("image/") ||
+                        contentType.contains("application/octet-stream")
+                        )) {
+            dataString = "$contentLength bytes of ${guessContentType()}"
         } else if (data.isNotEmpty()) {
             dataString = String(data)
         }
@@ -73,7 +66,7 @@ class Response(
         }
 
         val contentTypeFromStream = URLConnection.guessContentTypeFromStream(ByteArrayInputStream(data))
-        return if(contentTypeFromStream.isNullOrEmpty()) "unknown" else contentTypeFromStream
+        return if(contentTypeFromStream.isNullOrEmpty()) "(unknown)" else contentTypeFromStream
     }
 
     companion object {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
@@ -35,16 +35,16 @@ class Response(
     }
 
     override  fun toString(): String {
-        var dataString = "(empty)"
         val contentType = guessContentType()
 
-        if (contentType.isNotEmpty() &&
-                (contentType.contains("image/") ||
-                        contentType.contains("application/octet-stream")
-                        )) {
-            dataString = "$contentLength bytes of ${guessContentType()}"
+        val dataString = if (contentType.isNotEmpty() &&
+                            (contentType.contains("image/") ||
+                            contentType.contains("application/octet-stream"))) {
+             "$contentLength bytes of ${guessContentType()}"
         } else if (data.isNotEmpty()) {
-            dataString = String(data)
+             String(data)
+        } else {
+            "(empty)"
         }
 
         return buildString {
@@ -66,7 +66,7 @@ class Response(
         }
 
         val contentTypeFromStream = URLConnection.guessContentTypeFromStream(ByteArrayInputStream(data))
-        return if(contentTypeFromStream.isNullOrEmpty()) "(unknown)" else contentTypeFromStream
+        return if (contentTypeFromStream.isNullOrEmpty()) "(unknown)" else contentTypeFromStream
     }
 
     companion object {

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -162,6 +162,7 @@ class RequestTest : BaseTestCase() {
         assertThat(data, notNullValue())
 
         assertThat(response?.guessContentType(), isEqualTo("application/octet-stream"))
+        assertThat(response?.toString(), containsString("Body : (555 bytes of application/octet-stream)"))
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response?.statusCode, isEqualTo(statusCode))

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -63,6 +63,32 @@ class RequestTest : BaseTestCase() {
     }
 
     @Test
+    fun testResponseURLShouldSameWithRequestURL() {
+        var request: Request? = null
+        var response: Response? = null
+        var data: Any? = null
+        var error: FuelError? = null
+
+        manager.request(Method.GET, "http://httpbin.org/get").response { req, res, result ->
+            request = req
+            response = res
+
+            val (d, err) = result
+            data = d
+            error = err
+        }
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(request?.url, notNullValue())
+        assertThat(response?.url, notNullValue())
+        assertThat(request?.url, isEqualTo(response?.url))
+    }
+
+    @Test
     fun httpGetRequestWithDataResponse() {
         var request: Request? = null
         var response: Response? = null
@@ -170,7 +196,6 @@ class RequestTest : BaseTestCase() {
     fun testProcessBodyWithUnknownContentTypeAndNoData() {
         var request: Request? = null
         var response: Response? = null
-        var data: Any? = null
         var error: FuelError? = null
 
         manager.request(Method.GET, "http://httpbin.org/bytes/555").responseString { req, res, result ->
@@ -178,7 +203,6 @@ class RequestTest : BaseTestCase() {
             response = res
 
             val (d, err) = result
-            data = d
             error = err
         }
 

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -105,8 +105,63 @@ class RequestTest : BaseTestCase() {
 
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
+        assertThat(response?.guessContentType(), isEqualTo("application/json"))
         assertThat(error, nullValue())
         assertThat(data, notNullValue())
+
+        val statusCode = HttpURLConnection.HTTP_OK
+        assertThat(response?.statusCode, isEqualTo(statusCode))
+    }
+
+    @Test
+    fun httpGetRequestWithImageResponse() {
+        var request: Request? = null
+        var response: Response? = null
+        var data: Any? = null
+        var error: FuelError? = null
+
+        manager.request(Method.GET, "http://httpbin.org/image/png").responseString { req, res, result ->
+            request = req
+            response = res
+
+            val (d, err) = result
+            data = d
+            error = err
+        }
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response?.guessContentType(), isEqualTo("image/png"))
+
+        val statusCode = HttpURLConnection.HTTP_OK
+        assertThat(response?.statusCode, isEqualTo(statusCode))
+    }
+
+    @Test
+    fun httpGetRequestWithBytesResponse() {
+        var request: Request? = null
+        var response: Response? = null
+        var data: Any? = null
+        var error: FuelError? = null
+
+        manager.request(Method.GET, "http://httpbin.org/bytes/555").responseString { req, res, result ->
+            request = req
+            response = res
+
+            val (d, err) = result
+            data = d
+            error = err
+        }
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response?.guessContentType(), isEqualTo("application/octet-stream"))
 
         val statusCode = HttpURLConnection.HTTP_OK
         assertThat(response?.statusCode, isEqualTo(statusCode))
@@ -539,5 +594,6 @@ class RequestTest : BaseTestCase() {
 
         assertThat(request.cUrlString(), isEqualTo("$ curl -i -X POST -H \"Authentication:Bearer xxx\" http://httpbin.org/post"))
     }
+
 }
 


### PR DESCRIPTION
## What's in this PR?
- Add `guessContentType(): String` to `Response`. It either checks `Content-type` in response header or   from `byteArrayInputStream`
- A bit improve version of response.toString()
From this:

```
<-- 200 (http://httpbin.org/image/png?key=value)
                                                        Response : OK
                                                        Length : 8090
                                                        Body : ��#�I��b6��Xv�8N:e�C�}����`�^L�:�~�Mw�I��W..... (and more 8kb of nonsense bytedata)
``` 

To this:

```
<-- 200 (http://httpbin.org/image/png?key=value)
                                                        Response : OK
                                                        Length : 8090
                                                        Body : (8090 bytes of image/png)
```

### What _isn't_ in this PR?
 - flexible .toString() for `Request` #240  (Still figuring better solution for this.)