### PR TITLE
add httpString()

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -241,6 +241,20 @@ class Request(
         }
     }
 
+    fun httpString(): String = buildString {
+        // url
+        val params = parameters.map { "${it.first}=${it.second}" }.joinToString(separator = "&", prefix = "?")
+        appendln("${method.value} ${url}${params}")
+        appendln()
+        // headers
+        for ((key, value) in headers) {
+            appendln("$key : $value")
+        }
+        // body
+        appendln()
+        appendln(String(getHttpBody()))
+    }
+
     fun cUrlString(): String = buildString {
         append("$ curl -i")
 

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -691,5 +691,26 @@ class RequestTest : BaseTestCase() {
         assertThat(request.cUrlString(), isEqualTo("$ curl -i -X POST -H \"Authentication:Bearer xxx\" http://httpbin.org/post"))
     }
 
+    @Test
+    fun httpStringWithOutParams(){
+        val request = Request(Method.GET, "",
+                url = URL("http://httpbin.org/post"),
+                headers = mutableMapOf("Content-Type" to "text/html"))
+
+        assertThat(request.httpString(), startsWith("GET http"))
+        assertThat(request.httpString(), containsString("Content-Type"))
+    }
+
+    @Test
+    fun httpStringWithParams(){
+        val request = Request(Method.POST, "",
+                url = URL("http://httpbin.org/post"),
+                headers = mutableMapOf("Content-Type" to "text/html"),
+                parameters = listOf("foo" to "xxx")).body("it's a body")
+
+        assertThat(request.httpString(), startsWith("POST http"))
+        assertThat(request.httpString(), containsString("Content-Type"))
+        assertThat(request.httpString(), containsString("body"))
+    }
 }
 


### PR DESCRIPTION
Request.toString() method shows headers first and body second.
I wanna see the Request as HTTP protocol like this:

> GET https://www.example.com/path
> 
> Content-Type: text/plain
> Accept-Encoding : compress;q=0.5, gzip;q=1.0
>
> Request body string
> 
