### PR TITLE
Add support to routing to send json call

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,18 +641,21 @@ sealed class WeatherApi: FuelRouting {
     override val basePath = "https://www.metaweather.com"
 
     class weatherFor(val location: String): WeatherApi() {}
+    class weatherSpecific(val location: String) : WeatherApi() {}
 
     override val method: Method
         get() {
             when(this) {
-                is weatherFor -> return Method.GET
+                is weatherFor -> return Method.GET,
+		is weatherSpecific -> return Method.POST
             }
         }
 
     override val path: String
         get() {
             return when(this) {
-                is weatherFor -> "/api/location/search/"
+                is weatherFor -> "/api/location/search/",
+		is weatherSpecific -> "/api/location/search/"
             }
         }
 
@@ -660,6 +663,17 @@ sealed class WeatherApi: FuelRouting {
         get() {
             return when(this) {
                 is weatherFor -> listOf("query" to this.location)
+		is weatherSpecific -> listOf()
+            }
+        }
+	
+	override val body: String?
+        get() = when (this) {
+            is weatherFor -> null
+            is weatherSpecific -> {
+                val json = JSONObject()
+                json.put("location", this.location)
+                json.toString()
             }
         }
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
@@ -27,6 +27,10 @@ interface FuelRouting: Fuel.RequestConvertible {
      */
     val params: List<Pair<String, Any?>>?
     /**
+     * Body to handle other type of request (e.g. application/json )
+     */
+    val body: String?
+    /**
      * Headers for remote call.
      */
     val headers: Map<String, String>?
@@ -45,6 +49,9 @@ interface FuelRouting: Fuel.RequestConvertible {
                     urlString = path,
                     parameters = params
             )
+            body?.let {
+                encoder.request.body(it)
+            }
             // return the generated encoder with custom header injected
             return encoder.request.header(headers)
         }


### PR DESCRIPTION
I've updated the FuelRouting to easily manage eg. JSON POST call manipulating `body` object