### PR TITLE
FuelRouting / Add support for Json request

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,18 +641,21 @@ sealed class WeatherApi: FuelRouting {
     override val basePath = "https://www.metaweather.com"
 
     class weatherFor(val location: String): WeatherApi() {}
+    class weatherSpecific(val location: String) : WeatherApi() {}
 
     override val method: Method
         get() {
             when(this) {
-                is weatherFor -> return Method.GET
+                is weatherFor -> return Method.GET,
+		is weatherSpecific -> return Method.POST
             }
         }
 
     override val path: String
         get() {
             return when(this) {
-                is weatherFor -> "/api/location/search/"
+                is weatherFor -> "/api/location/search/",
+		is weatherSpecific -> "/api/location/search/"
             }
         }
 
@@ -660,6 +663,17 @@ sealed class WeatherApi: FuelRouting {
         get() {
             return when(this) {
                 is weatherFor -> listOf("query" to this.location)
+		is weatherSpecific -> listOf()
+            }
+        }
+	
+	override val body: String?
+        get() = when (this) {
+            is weatherFor -> null
+            is weatherSpecific -> {
+                val json = JSONObject()
+                json.put("location", this.location)
+                json.toString()
             }
         }
 

--- a/fuel/build.gradle
+++ b/fuel/build.gradle
@@ -15,6 +15,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     compile "com.github.kittinunf.result:result:$resultVersion"
+    compile 'org.json:json:20160212'
 
     testCompile "junit:junit:$junitVersion"
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
@@ -27,6 +27,10 @@ interface FuelRouting: Fuel.RequestConvertible {
      */
     val params: List<Pair<String, Any?>>?
     /**
+     * Body to handle other type of request (e.g. application/json )
+     */
+    val body: String?
+    /**
      * Headers for remote call.
      */
     val headers: Map<String, String>?
@@ -45,6 +49,9 @@ interface FuelRouting: Fuel.RequestConvertible {
                     urlString = path,
                     parameters = params
             )
+            body?.let {
+                encoder.request.body(it)
+            }
             // return the generated encoder with custom header injected
             return encoder.request.header(headers)
         }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -1,6 +1,11 @@
 package com.github.kittinunf.fuel
 
-import com.github.kittinunf.fuel.core.*
+import com.github.kittinunf.fuel.core.Encoding
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.FuelManager
+import com.github.kittinunf.fuel.core.Method
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
 import org.hamcrest.CoreMatchers.*
 import org.junit.Assert.assertThat
 import org.junit.Test
@@ -699,7 +704,9 @@ class RequestTest : BaseTestCase() {
     fun httpStringWithOutParams(){
         val request = Request(Method.GET, "",
                 url = URL("http://httpbin.org/post"),
-                headers = mutableMapOf("Content-Type" to "text/html"))
+                headers = mutableMapOf("Content-Type" to "text/html"),
+                timeoutInMillisecond = 15000,
+                timeoutReadInMillisecond = 15000)
 
         assertThat(request.httpString(), startsWith("GET http"))
         assertThat(request.httpString(), containsString("Content-Type"))
@@ -710,7 +717,9 @@ class RequestTest : BaseTestCase() {
         val request = Request(Method.POST, "",
                 url = URL("http://httpbin.org/post"),
                 headers = mutableMapOf("Content-Type" to "text/html"),
-                parameters = listOf("foo" to "xxx")).body("it's a body")
+                parameters = listOf("foo" to "xxx"),
+                timeoutInMillisecond = 15000,
+                timeoutReadInMillisecond = 15000).body("it's a body")
 
         assertThat(request.httpString(), startsWith("POST http"))
         assertThat(request.httpString(), containsString("Content-Type"))

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RoutingTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RoutingTest.kt
@@ -157,7 +157,7 @@ class RoutingTest: BaseTestCase() {
             val statusCode = HttpURLConnection.HTTP_OK
             assertThat(response?.statusCode, isEqualTo(statusCode))
 
-            assertThat(string, containsString("42"))
+            //assertThat(string, containsString("42"))
         }
     }
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RoutingTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RoutingTest.kt
@@ -45,6 +45,11 @@ class RoutingTest: BaseTestCase() {
                     else -> null
                 }
             }
+        
+        override val body: String?
+            get() {
+                return null
+            }
 
         override val headers: Map<String, String>?
             get() {

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RoutingTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RoutingTest.kt
@@ -29,7 +29,7 @@ class RoutingTest: BaseTestCase() {
                 return when (this) {
                     is GetTest -> Method.GET
                     is GetParamsTest -> Method.GET
-                    is GetBodyTest -> Method.GET
+                    is GetBodyTest -> Method.POST
                 }
             }
 
@@ -157,7 +157,7 @@ class RoutingTest: BaseTestCase() {
             val statusCode = HttpURLConnection.HTTP_OK
             assertThat(response?.statusCode, isEqualTo(statusCode))
 
-            //assertThat(string, containsString("42"))
+            assertThat(string, containsString("42"))
         }
     }
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RoutingTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RoutingTest.kt
@@ -1,6 +1,7 @@
 package com.github.kittinunf.fuel
 
 import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.Method
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
@@ -17,6 +18,8 @@ import org.hamcrest.CoreMatchers.`is` as isEqualTo
  */
 class RoutingTest: BaseTestCase() {
     sealed class TestApi : FuelRouting {
+
+        private val manager: FuelManager by lazy { FuelManager() }
 
         override val basePath = "https://httpbin.org/"
 
@@ -77,7 +80,7 @@ class RoutingTest: BaseTestCase() {
             var data: Any? = null
             var error: FuelError? = null
 
-            Fuel.request(TestApi.GetTest()).responseString { req, res, result ->
+            manager.request(TestApi.GetTest()).responseString { req, res, result ->
                 request = req
                 response = res
 
@@ -106,7 +109,7 @@ class RoutingTest: BaseTestCase() {
             val paramKey = "foo"
             val paramValue = "bar"
 
-            Fuel.request(TestApi.GetParamsTest(name = paramKey, value = paramValue)).responseString { req, res, result ->
+            manager.request(TestApi.GetParamsTest(name = paramKey, value = paramValue)).responseString { req, res, result ->
                 request = req
                 response = res
 
@@ -138,7 +141,7 @@ class RoutingTest: BaseTestCase() {
 
             val paramValue = "42"
 
-            Fuel.request(TestApi.GetBodyTest(paramValue)).responseString { req, res, result ->
+            manager.request(TestApi.GetBodyTest(paramValue)).responseString { req, res, result ->
                 request = req
                 response = res
 


### PR DESCRIPTION
- Added support to JSON request to FuelRouting allowing injecting value in `body`
- Updated readme
- Updated test