### PR TITLE
An extra space was causing InterceptorTest test to always fail

### DIFF
--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/InterceptorTest.kt
@@ -229,7 +229,7 @@ class InterceptorTest : BaseTestCase() {
         assertThat(request, notNullValue())
         assertThat(response, notNullValue())
         assertThat(error, nullValue())
-        assertThat(data, containsString("\"user-agent\": \"Fuel\""))
+        assertThat(data, containsString("\"user-agent\":\"Fuel\""))
 
         assertThat(response.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
     }


### PR DESCRIPTION
Noticed that this test was always failing. The test was expecting `"user-agent": "Fuel"`, but the response was returning  `"user-agent":"Fuel"`.

The missing space after the `:` was causing it to always return a failure.