### PR TITLE
Improve error handling of coroutines API

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ Fuel.request(WeatherApi.weatherFor("london")).responseJson { request, response, 
         }
 ```
 
-## Coroutines Support
+### Coroutines Support
 
 Coroutines module provides extension functions to wrap a response inside a coroutine and handle its result. The coroutines-based API provides equivalent methods to the standard API (e.g: `responseString()` in coroutines is `awaitString()`).
 

--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ Coroutines module provides extension functions to wrap a response inside a corou
 runBlocking {
     val (request, response, result) = Fuel.get("https://httpbin.org/ip").awaitString()
 
-result.fold({ data ->
+    result.fold({ data ->
         println(data) // "{"origin":"127.0.0.1"}"
     }, { error ->
         println("An error of type ${error.exception} happened: ${error.message}")

--- a/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
+++ b/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
@@ -32,7 +32,9 @@ suspend fun <U : Any> Request.awaitObject(
         deserializable: ResponseDeserializable<U>
 ): Triple<Request, Response, Result<U, FuelError>> = await(deserializable)
 
-suspend fun Request.awaitResponseResult(): ByteArray = awaitResponse().third.get()
+suspend fun Request.awaitResponseResult(): ByteArray = awaitResponse().third
+        .mapError { throw it.exception }
+        .get()
 
 suspend fun Request.awaitStringResult(
         charset: Charset = Charsets.UTF_8

--- a/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
+++ b/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
@@ -50,7 +50,9 @@ suspend fun Request.awaitStringResult(
  * */
 suspend fun <U : Any> Request.awaitObjectResult(
         deserializable: ResponseDeserializable<U>
-): U = await(deserializable).third.get()
+): U = await(deserializable).third
+        .mapError { throw it.exception }
+        .get()
 
 /**
  * This function catches both server errors and Deserialization Errors

--- a/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
+++ b/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
@@ -22,6 +22,12 @@ suspend fun Request.awaitString(
         charset: Charset = Charsets.UTF_8
 ): Triple<Request, Response, Result<String, FuelError>> = await(stringDeserializer(charset))
 
+@Deprecated(
+        replaceWith = ReplaceWith(
+                expression = ".awaitSafelyObjectResult"),
+        level = DeprecationLevel.WARNING,
+        message = "This functions cannot handle exceptions properly which causes API inconsistency."
+)
 suspend fun <U : Any> Request.awaitObject(
         deserializable: ResponseDeserializable<U>
 ): Triple<Request, Response, Result<U, FuelError>> = await(deserializable)

--- a/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
+++ b/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
@@ -32,14 +32,17 @@ suspend fun Request.awaitString(
         level = DeprecationLevel.WARNING,
         message = "This functions cannot handle exceptions properly which causes API inconsistency."
 )
+@Throws
 suspend fun <U : Any> Request.awaitObject(
         deserializable: ResponseDeserializable<U>
 ): Triple<Request, Response, Result<U, FuelError>> = await(deserializable)
 
+@Throws
 suspend fun Request.awaitResponseResult(): ByteArray = awaitResponse().third
         .mapError { throw it.exception }
         .get()
 
+@Throws
 suspend fun Request.awaitStringResult(
         charset: Charset = Charsets.UTF_8
 ): String = awaitString(charset).third
@@ -54,6 +57,7 @@ suspend fun Request.awaitStringResult(
  *
  * @return Result object
  * */
+@Throws
 suspend fun <U : Any> Request.awaitObjectResult(
         deserializable: ResponseDeserializable<U>
 ): U = await(deserializable).third

--- a/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
+++ b/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
@@ -30,8 +30,7 @@ suspend fun Request.awaitString(
         replaceWith = ReplaceWith(
                 expression = ".awaitSafelyObjectResult"),
         level = DeprecationLevel.WARNING,
-        message = "This functions cannot handle exceptions properly which causes API inconsistency."
-)
+        message = "This function cannot handle exceptions properly which causes API inconsistency.")
 @Throws
 suspend fun <U : Any> Request.awaitObject(
         deserializable: ResponseDeserializable<U>

--- a/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
+++ b/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
@@ -1,6 +1,11 @@
-import com.github.kittinunf.fuel.core.*
+import com.github.kittinunf.fuel.core.Deserializable
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Request.Companion.byteArrayDeserializer
 import com.github.kittinunf.fuel.core.Request.Companion.stringDeserializer
+import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.fuel.core.ResponseDeserializable
+import com.github.kittinunf.fuel.core.response
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.mapError
 import kotlinx.coroutines.experimental.suspendCancellableCoroutine
@@ -13,7 +18,6 @@ private suspend fun <T : Any, U : Deserializable<T>> Request.await(
             continuation.invokeOnCancellation { cancel() }
             continuation.resume(response(deserializable))
         }
-
 
 suspend fun Request.awaitResponse(): Triple<Request, Response, Result<ByteArray, FuelError>> =
         await(byteArrayDeserializer())
@@ -74,4 +78,3 @@ suspend fun <U : Any> Request.awaitSafelyObjectResult(
     }
     Result.Failure(fuelError)
 }
-

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -124,8 +124,24 @@ class CoroutinesTest {
     }
 
     @Test
-    fun testItCanAwaitForObjectResult() = runBlocking {
-        assertTrue(Fuel.get("/uuid").awaitObjectResult(UUIDResponseDeserializer).uuid.isNotEmpty())
+    fun testAwaitObjectResultSuccess() = runBlocking {
+        try {
+            val data = Fuel.get("/uuid").awaitObjectResult(UUIDResponseDeserializer)
+            assertTrue(data.uuid.isNotEmpty())
+        } catch (exception: Exception) {
+            fail("This test should pass but got an exception: ${exception.message}")
+        }
+    }
+
+    @Test
+    fun testAwaitObjectResultExceptionDueToNetwork() = runBlocking {
+        try {
+            Fuel.get("/some/invalid/path").awaitObjectResult(UUIDResponseDeserializer)
+            fail("This test should raise an exception due to invalid URL")
+        } catch (exception: HttpException) {
+            assertNotNull(exception)
+            assertTrue(exception.message.orEmpty().contains("404"))
+        }
     }
 
     @Test

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -145,6 +145,16 @@ class CoroutinesTest {
     }
 
     @Test
+    fun testAwaitObjectResultExceptionDueToSerialization() = runBlocking {
+        try {
+            Fuel.get("/uuid").awaitObjectResult(UUIDIntResponseDeserializer)
+            fail("This test should fail because uuid property should be a String.")
+        } catch (exception: JsonMappingException) {
+            assertNotNull(exception)
+        }
+    }
+
+    @Test
     fun testItCanAwaitResponseResult() = runBlocking {
         assertTrue(Fuel.get("/uuid").awaitResponseResult().isNotEmpty())
     }

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -124,6 +124,16 @@ class CoroutinesTest {
     }
 
     @Test
+    fun testAwaitStringResultSuccess() = runBlocking {
+        try {
+            val data = Fuel.get("/uuid").awaitStringResult()
+            assertTrue(data.contains("uuid"))
+        } catch (exception: Exception) {
+            fail("This test should pass but got an exception: ${exception.message}")
+        }
+    }
+
+    @Test
     fun testAwaitResponseResultSuccess() = runBlocking {
         try {
             val data = Fuel.get("/uuid").awaitResponseResult()
@@ -162,11 +172,6 @@ class CoroutinesTest {
         } catch (exception: JsonMappingException) {
             assertNotNull(exception)
         }
-    }
-
-    @Test
-    fun testItCanAwaitForStringResult() = runBlocking {
-        assertTrue(Fuel.get("/uuid").awaitStringResult().isNotEmpty())
     }
 
     @Test

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -19,13 +19,24 @@ class CoroutinesTest {
     }
 
     @Test
-    fun testItCanAwaitForAnError() = runBlocking {
+    fun testAwaitStringSuccess() = runBlocking {
+        Fuel.get("/uuid").awaitString().third
+                .fold({ data ->
+                    assertTrue(data.isNotEmpty())
+                    assertTrue(data.contains("uuid"))
+                }, { error ->
+                    fail("This test should pass but got an error: ${error.message}")
+                })
+    }
+
+    @Test
+    fun testAwaitStringErrorDueToNetwork() = runBlocking {
         try {
             Fuel.get("/not/found/address").awaitString().third.fold({
                 fail("This test should fail due to HTTP status code.")
             }, { error ->
                 assertTrue(error.exception is HttpException)
-                assertTrue(error.message!!.contains("HTTP Exception 404"))
+                assertTrue(error.message.orEmpty().contains("HTTP Exception 404"))
             })
         } catch (exception: HttpException) {
             fail("When using awaitString errors should be folded instead of thrown.")
@@ -44,17 +55,6 @@ class CoroutinesTest {
         } catch (exception: HttpException) {
             fail("When using awaitString errors should be folded instead of thrown.")
         }
-    }
-
-    @Test
-    fun testItCanAwaitString() = runBlocking {
-        Fuel.get("/uuid").awaitString().third
-                .fold({ data ->
-                    assertTrue(data.isNotEmpty())
-                    assertTrue(data.contains("uuid"))
-                }, { error ->
-                    fail("This test should pass but got an error: ${error.message}")
-                })
     }
 
     @Test

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -44,27 +44,27 @@ class CoroutinesTest {
     }
 
     @Test
-    fun testAwaitResponseError() = runBlocking {
-        try {
-            Fuel.get("/not/found/address").awaitResponse().third.fold({
-                fail("This test should fail due to HTTP status code.")
-            }, { error ->
-                assertTrue(error.exception is HttpException)
-                assertTrue(error.message!!.contains("HTTP Exception 404"))
-            })
-        } catch (exception: HttpException) {
-            fail("When using awaitString errors should be folded instead of thrown.")
-        }
-    }
-
-    @Test
-    fun testItCanAwaitByteArray() = runBlocking {
+    fun testAwaitResponseSuccess() = runBlocking {
         Fuel.get("/ip").awaitResponse().third
                 .fold({ data ->
                     assertTrue(data.isNotEmpty())
                 }, { error ->
                     fail("This test should pass but got an error: ${error.message}")
                 })
+    }
+
+    @Test
+    fun testAwaitResponseErrorDueToNetwork() = runBlocking {
+        try {
+            Fuel.get("/invalid/url").awaitResponse().third.fold({
+                fail("This test should fail due to HTTP status code.")
+            }, { error ->
+                assertTrue(error.exception is HttpException)
+                assertTrue(error.message!!.contains("HTTP Exception 404"))
+            })
+        } catch (exception: HttpException) {
+            fail("When using awaitResponse errors should be folded instead of thrown.")
+        }
     }
 
     private data class UUIDResponse(val uuid: String)

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -121,12 +121,12 @@ class CoroutinesTest {
     }
 
     @Test
-    fun testAwaitObjectDueToSerialization() = runBlocking {
+    fun testAwaitObjectDueToDeserialization() = runBlocking {
         try {
             Fuel.get("/uuid").awaitObject(UUIDIntResponseDeserializer).third.fold({
                 fail("This test should fail because uuid property should be a String.")
             }, {
-                fail("When using awaitObject serialization errors are thrown.")
+                fail("When using awaitObject serialization/deserialization errors are thrown.")
             })
         } catch (exception: JsonMappingException) {
             assertNotNull(exception)
@@ -175,7 +175,7 @@ class CoroutinesTest {
     }
 
     @Test
-    fun testAwaitObjectResultExceptionDueToSerialization() = runBlocking {
+    fun testAwaitObjectResultExceptionDueToDeserialization() = runBlocking {
         try {
             Fuel.get("/uuid").awaitObjectResult(UUIDIntResponseDeserializer)
             fail("This test should fail because uuid property should be a String.")

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -124,6 +124,16 @@ class CoroutinesTest {
     }
 
     @Test
+    fun testAwaitResponseResultSuccess() = runBlocking {
+        try {
+            val data = Fuel.get("/uuid").awaitResponseResult()
+            assertTrue(data.isNotEmpty())
+        } catch (exception: Exception) {
+            fail("This test should pass but got an exception: ${exception.message}")
+        }
+    }
+
+    @Test
     fun testAwaitObjectResultSuccess() = runBlocking {
         try {
             val data = Fuel.get("/uuid").awaitObjectResult(UUIDResponseDeserializer)
@@ -152,11 +162,6 @@ class CoroutinesTest {
         } catch (exception: JsonMappingException) {
             assertNotNull(exception)
         }
-    }
-
-    @Test
-    fun testItCanAwaitResponseResult() = runBlocking {
-        assertTrue(Fuel.get("/uuid").awaitResponseResult().isNotEmpty())
     }
 
     @Test

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -23,13 +23,17 @@ class CoroutinesTest {
 
     @Test
     fun testAwaitStringSuccess() = runBlocking {
-        Fuel.get("/uuid").awaitString().third
-                .fold({ data ->
-                    assertTrue(data.isNotEmpty())
-                    assertTrue(data.contains("uuid"))
-                }, { error ->
-                    fail("This test should pass but got an error: ${error.message}")
-                })
+        try {
+            Fuel.get("/uuid").awaitString().third
+                    .fold({ data ->
+                        assertTrue(data.isNotEmpty())
+                        assertTrue(data.contains("uuid"))
+                    }, { error ->
+                        fail("This test should pass but got an error: ${error.message}")
+                    })
+        } catch (exception: Exception) {
+            fail("When using awaitString errors should be folded instead of thrown.")
+        }
     }
 
     @Test
@@ -48,12 +52,16 @@ class CoroutinesTest {
 
     @Test
     fun testAwaitResponseSuccess() = runBlocking {
-        Fuel.get("/ip").awaitResponse().third
-                .fold({ data ->
-                    assertTrue(data.isNotEmpty())
-                }, { error ->
-                    fail("This test should pass but got an error: ${error.message}")
-                })
+        try {
+            Fuel.get("/ip").awaitResponse().third
+                    .fold({ data ->
+                        assertTrue(data.isNotEmpty())
+                    }, { error ->
+                        fail("This test should pass but got an error: ${error.message}")
+                    })
+        } catch (exception: Exception) {
+            fail("When using awaitResponse errors should be folded instead of thrown.")
+        }
     }
 
     @Test

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -21,11 +21,28 @@ class CoroutinesTest {
     @Test
     fun testItCanAwaitForAnError() = runBlocking {
         try {
-            Fuel.get("/not/found/address").awaitString()
-            fail("This test should fail due to status code 404")
+            Fuel.get("/not/found/address").awaitString().third.fold({
+                fail("This test should fail due to HTTP status code.")
+            }, { error ->
+                assertTrue(error.exception is HttpException)
+                assertTrue(error.message!!.contains("HTTP Exception 404"))
+            })
         } catch (exception: HttpException) {
-            assertNotNull(exception)
-            assertTrue(exception.message!!.contains("HTTP Exception 404"))
+            fail("When using awaitString errors should be folded instead of thrown.")
+        }
+    }
+
+    @Test
+    fun testAwaitResponseError() = runBlocking {
+        try {
+            Fuel.get("/not/found/address").awaitResponse().third.fold({
+                fail("This test should fail due to HTTP status code.")
+            }, { error ->
+                assertTrue(error.exception is HttpException)
+                assertTrue(error.message!!.contains("HTTP Exception 404"))
+            })
+        } catch (exception: HttpException) {
+            fail("When using awaitString errors should be folded instead of thrown.")
         }
     }
 
@@ -109,7 +126,7 @@ class CoroutinesTest {
                     .fold({ _ ->
                         fail("This is an error case!")
                     }, { error ->
-                        assertTrue( error.exception is HttpException)
+                        assertTrue(error.exception is HttpException)
                     })
         } catch (e: Exception) {
             fail("this should have been caught")

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/CoroutinesTest.kt
@@ -6,7 +6,9 @@ import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.HttpException
 import com.github.kittinunf.fuel.core.ResponseDeserializable
 import kotlinx.coroutines.experimental.runBlocking
-import org.junit.Assert.*
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class CoroutinesTest {


### PR DESCRIPTION
This pull request is indented to address the issue #365. This makes the coroutines functions to behave like the standard API regarding how the client should handle errors and exceptions.

To make sure that they're consistent, the `awaitObject` function was deprecated in favor of `awaitSafelyObjectResult` (#369) because it seems not to be possible to handle serialization/deserialization exceptions.

The test suite was also refactored to add missing test cases. Although there are none tests to verify the error handling of serialization/deserialization of `awaitResponse` and `awaitString` because I don't know how to make them fail.

| Standard API | Equivalent API using Coroutines | Error type | Handling method
| :--- | :--- | :--- | :--- |
| response | awaitResponse | FuelError | fold |
| responseString | awaitString | FuelError | fold |
| responseObject | ~~awaitObject~~ | FuelError | fold |
| --- | awaitSafelyObjectResult | FuelError | fold |
| --- | awaitResponseResult | Exception | try-catch |
| --- | awaitStringResult | Exception | try-catch |
| --- | awaitObjectResult | Exception | try-catch |

Please, let me know if you have any comments.