### PR TITLE
 🐛 Fix request toString

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -238,6 +238,7 @@ class Request(
         get() = this
 
     override fun toString(): String = buildString {
+        appendln("--> $url")
         appendln("\"Body : ${if (getHttpBody().isNotEmpty()) String(getHttpBody()) else "(empty)"}\"")
         appendln("\"Headers : (${headers.size})\"")
         for ((key, value) in headers) {


### PR DESCRIPTION
### What's in this PR?

This PR fixes the `fun toString()` in Request as the url seems to be missing out.

This is how it looks like

```
--> http://httpbin.org/get?foo=bar
"Body : (empty)"
"Headers : (1)"
Accept-Encoding : compress;q=0.5, gzip;q=1.0
```