### PR TITLE
Update Jackson version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         junitVersion = '4.12'
         robolectricVersion = '3.8'
         gsonVersion = '2.8.2'
-        jacksonVersion = '2.9.3'
+        jacksonVersion = '2.9.6'
         moshiVersion = '1.5.0'
         runnerVersion = '1.0.0'
         rulesVersion = '1.0.0'

--- a/fuel-jackson/src/test/kotlin/com/github/kittinunf/fuel/FuelJacksonTest.kt
+++ b/fuel-jackson/src/test/kotlin/com/github/kittinunf/fuel/FuelJacksonTest.kt
@@ -101,7 +101,8 @@ class FuelJacksonTest {
 
     @Test
     fun jacksonTestResponseSyncObject() {
-        val (_, res, result) = Fuel.get("https://api.github.com/repos/kittinunf/Fuel/issues/1").responseObject<IssueInfo>()
+        val (_, res, result) =
+                Fuel.get("https://api.github.com/repos/kittinunf/Fuel/issues/1").responseObject<IssueInfo>()
         assertThat(res, notNullValue())
         assertThat(result.get(), notNullValue())
         assertThat(result.get(), isA(IssueInfo::class.java))


### PR DESCRIPTION
### What's in this PR?

This PR update Jackson version. This is due to the internal request by the client that use this module.

PS. This also updates our randomly fail test. So that we don't have to get a false positive.