### PR TITLE
Added ByteArray property to handle binary data with FuelRouting

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
@@ -27,6 +27,10 @@ interface FuelRouting: Fuel.RequestConvertible {
      */
     val params: List<Pair<String, Any?>>?
     /**
+     * Body to handle binary type of request (e.g. application/octet-stream )
+     */
+    val bytes: ByteArray?
+    /**
      * Body to handle other type of request (e.g. application/json )
      */
     val body: String?
@@ -49,7 +53,9 @@ interface FuelRouting: Fuel.RequestConvertible {
                     urlString = path,
                     parameters = params
             )
-            body?.let {
+            bytes?.let {
+                encoder.request.body(it)
+            } ?: body?.let {
                 encoder.request.body(it)
             }
             // return the generated encoder with custom header injected

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/FuelRouting.kt
@@ -53,9 +53,9 @@ interface FuelRouting: Fuel.RequestConvertible {
                     urlString = path,
                     parameters = params
             )
-            bytes?.let {
+            body?.let {
                 encoder.request.body(it)
-            } ?: body?.let {
+            } ?: bytes?.let {
                 encoder.request.body(it)
             }
             // return the generated encoder with custom header injected


### PR DESCRIPTION
In this PR, I added byte array properties to FuelRouting to directly set ByteArray to message body when POSTing binary data such as Base64 and Protobuf data.

FuelRouting class will have ByteArray and String properties as message body, ByteArray takes precedence.