### PR TITLE
Community and contributing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+# Bug Report
+
+## Description
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+```Kotlin
+// Test case or sample that shows broken behaviour and expected behaviour
+```
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+### Development Machine
+_Complete the following information if applicable_
+
+ - OS: [e.g. Windows 10]
+ - IDE: [e.g. Android Studio, IntelliJ, Eclipse]
+ - Fuel version: [e.g. 1.15.0]
+ - Kotlin version: [e.g. 1.2.51]
+
+### Smartphone or Emulator
+_Complete the following information if applicable_
+
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+# Feature Request
+
+## Description
+Is your feature request related to a problem? Please describe. This should be a
+clear and concise description of what the problem is. Ex. I work a lot with JSON
+requests and [...]
+
+## Proposed Solution
+A clear and concise description of what you want to happen. At least provided a
+high level description but feel free to include less abstract implementation
+ideas.
+
+## Alternatives I've considered
+A clear and concise description of any alternative solutions or features you've
+considered. Note any workaround you are currently using or why an alternative
+solution is sub-optimal for your use case.
+
+## Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/refactoring.md
+++ b/.github/ISSUE_TEMPLATE/refactoring.md
@@ -1,0 +1,24 @@
+---
+name: Refactoring
+about: Document a proposed refactoring / cosmetic changes not adding features or solving issues
+
+---
+# Refactoring
+
+## Description
+A clear and concise description of what should be done. In these files
+`file.kt`, we need to [...]
+
+## Files to process
+- [ ] File A
+- [ ] File B
+- [ ] File C
+
+## Why this is necessary**
+A clear and concise description of any alternative solutions you've considered,
+or what this impacts. Cosmetic changes usually don't add a lot but cost time to
+review and approve/reject/process and potentially merge, so there need to be
+gain such as readability, reduced complexity or improved Open/Closed design.
+
+## Additional context
+Add any other context or screenshots about the refactoring request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+Thank you for submitting your Pull Request. Please make sure you have
+familiarised yourself with the [Contributing Guidelines](https://github.com/kittunf/Fuel/CONTRIBUTING.md)
+before continuing.
+
+## Description
+
+Include a summary of the change and which [issue](https://github.com/kittunf/Fuel/issues)
+this fixes. Also include relevant motivation and context. List any dependencies
+that are required for this change and why they are necessary.
+
+Fixes #0
+Fixes #0
+
+## Type of change
+
+Check all that apply
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactoring (change which changes the current internal or external interface)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+In case you did not include tests describe why you and how you have verified the
+changes, with instructions so we can reproduce. If you have added comprehensive
+tests for your changes, you may ommit this section.
+
+## Checklist:
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation, if necessary
+- [ ] My changes generate no new compiler warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+The changelog for [Fuel](https://github.com/Fuel/Fuel) is located at the 
+[releases](https://github.com/kittinunf/Fuel/releases) page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Changelog
 
-The changelog for [Fuel](https://github.com/Fuel/Fuel) is located at the 
+The changelog for [Fuel](https://github.com/kittinunf/Fuel/) is located at the
 [releases](https://github.com/kittinunf/Fuel/releases) page.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [@kittinunf](https://twitter.com/kittinunf). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,57 +1,37 @@
 # How to contribute
 
 ## Found a :bug: bug or have a feature request?
-When you find a bug we'd like to know about it, and currently we accept feature requests, but before
-you submit one via [Github Issues](https://github.com/Fuel/Fuel/issues), please make sure that:
-- It is not already reported under [issues](https://github.com/Fuel/Fuel/issues),
-- If it's related to handling the HTTP requests or responses (caching, encoding, responses), you
-have looked up the [HTTP/1.1 RFC](https://tools.ietf.org/html/rfc2616), or when it's HTTP/2.0
-related, the [draft or released document](https://datatracker.ietf.org/wg/httpbis/documents/).
-- If it's a dependency issue such as an issue with livedata or gson, you make sure it related to
-the fuel integration.
+When you find a bug we'd like to know about it, and currently we accept feature requests, but before you submit one via [Github Issues](https://github.com/kittinunf/Fuel/issues), please make sure that:
+- It is not already reported under [issues](https://github.com/kittinunf/Fuel/issues),
+- If it's related to handling the HTTP requests or responses (caching, encoding, responses), you have looked up the [HTTP/1.1 RFC](https://tools.ietf.org/html/rfc2616), or when it's HTTP/2.0 related, the [draft or released document](https://datatracker.ietf.org/wg/httpbis/documents/).
+- If it's a dependency issue such as an issue with livedata or gson, you make sure it related to the fuel integration.
 
-If you're unable to find an open issue addressing the problem, or any issue (both closed or open)
-about the feature request, you may open a new one. Be sure to include a title and clear description,
-including as much relevant information as possible, and when submitting a bug report, preferably a
-code sample or an executable test case demonstrating the expected behavior that is not occurring.
+If you're unable to find an open issue addressing the problem, or any issue (both closed or open) about the feature request, you may open a new one. Be sure to include a title and clear description, including as much relevant information as possible, and when submitting a bug report, preferably a code sample or an executable test case demonstrating the expected behavior that is not occurring.
 
 ## Submitting changes (patch, fix, new feature implementation)
 
-Please send a GitHub Pull Request to [Fuel](https://github.com/Fuel) with a clear list of what you 
-have done (read more about [pull requests](https://help.github.com/articles/about-pull-requests/)).
+Please send a GitHub Pull Request to [Fuel](https://github.com/Fuel) with a clear list of what you have done (read more about [pull requests](https://help.github.com/articles/about-pull-requests/)).
 
-### Pull Request 
-In your Pull Request be sure to include a title and clear description on what it adds, removes or
-changes. The guidelines for commit messages below can be applied to the Pull Request as a whole.
+### Pull Request
+In your Pull Request be sure to include a title and clear description on what it adds, removes or changes. The guidelines for commit messages below can be applied to the Pull Request as a whole.
 
 ### Commit Messages
-Always write a clear log message for your commits. Thoughtbot has written a great 
-[article](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message) on better commit
-messages, and the following is taken and adapted from that article:
+Always write a clear log message for your commits. Thoughtbot has written a great [article](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message) on better commit messages, and the following is taken and adapted from that article:
 
-Other developers, especially you-in-two-weeks and you-from-next-year, will thank you for your
-forethought and verbosity when they run git blame to see why that conditional is there.
+Other developers, especially you-in-two-weeks and you-from-next-year, will thank you for your forethought and verbosity when they run git blame to see why that conditional is there.
 
-The first line should always be 50 characters or less and that it should be followed by a blank
-line. Many IDEs and editors ship with syntax, indent, and filetype plugins for Git commits which can
-help here.
+The first line should always be 50 characters or less and that it should be followed by a blank line. Many IDEs and editors ship with syntax, indent, and filetype plugins for Git commits which can help here.
 
 Answer the following questions:
 
 - **Why is this change necessary?**
 
-  This question tells reviewers of your pull request what to expect in the commit, allowing them to
-  more easily identify and point out unrelated changes.
+  This question tells reviewers of your pull request what to expect in the commit, allowing them to more easily identify and point out unrelated changes.
 
 - **How does it address the issue?**
-  
-  Describe, at a high level, what was done to affect change. Introduce a red/black tree to increase
-  search speed or Remove <troublesome depedency X>, which was causing <specific description of issue
-  introduced by depency> are good examples. If your change is obvious, you may be able to omit
-  addressing this question.
+
+  Describe, at a high level, what was done to affect change. "Introduce a red/black tree to increase search speed" or "Remove <troublesome depedency X>, which was causing <specific description of issue introduced by dependency>" are good examples. If your change is obvious, you may be able to omit addressing this question.
 
 - **What side effects does this change have?**
 
-  This is the most important question to answer, as it can point out problems where you are making
-  too many changes in one commit or branch. One or two bullet points for related changes may be
-  okay, but five or six are likely indicators of a commit that is doing too many things.
+  This is the most important question to answer, as it can point out problems where you are making too many changes in one commit or branch. One or two bullet points for related changes may be okay, but five or six are likely indicators of a commit that is doing too many things.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# How to contribute
+
+## Found a :bug: bug or have a feature request?
+When you find a bug we'd like to know about it, and currently we accept feature requests, but before
+you submit one via [Github Issues](https://github.com/Fuel/Fuel/issues), please make sure that:
+- It is not already reported under [issues](https://github.com/Fuel/Fuel/issues),
+- If it's related to handling the HTTP requests or responses (caching, encoding, responses), you
+have looked up the [HTTP/1.1 RFC](https://tools.ietf.org/html/rfc2616), or when it's HTTP/2.0
+related, the [draft or released document](https://datatracker.ietf.org/wg/httpbis/documents/).
+- If it's a dependency issue such as an issue with livedata or gson, you make sure it related to
+the fuel integration.
+
+If you're unable to find an open issue addressing the problem, or any issue (both closed or open)
+about the feature request, you may open a new one. Be sure to include a title and clear description,
+including as much relevant information as possible, and when submitting a bug report, preferably a
+code sample or an executable test case demonstrating the expected behavior that is not occurring.
+
+## Submitting changes (patch, fix, new feature implementation)
+
+Please send a GitHub Pull Request to [Fuel](https://github.com/Fuel) with a clear list of what you 
+have done (read more about [pull requests](https://help.github.com/articles/about-pull-requests/)).
+
+### Pull Request 
+In your Pull Request be sure to include a title and clear description on what it adds, removes or
+changes. The guidelines for commit messages below can be applied to the Pull Request as a whole.
+
+### Commit Messages
+Always write a clear log message for your commits. Thoughtbot has written a great 
+[article](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message) on better commit
+messages, and the following is taken and adapted from that article:
+
+Other developers, especially you-in-two-weeks and you-from-next-year, will thank you for your
+forethought and verbosity when they run git blame to see why that conditional is there.
+
+The first line should always be 50 characters or less and that it should be followed by a blank
+line. Many IDEs and editors ship with syntax, indent, and filetype plugins for Git commits which can
+help here.
+
+Answer the following questions:
+
+- **Why is this change necessary?**
+
+  This question tells reviewers of your pull request what to expect in the commit, allowing them to
+  more easily identify and point out unrelated changes.
+
+- **How does it address the issue?**
+  
+  Describe, at a high level, what was done to affect change. Introduce a red/black tree to increase
+  search speed or Remove <troublesome depedency X>, which was causing <specific description of issue
+  introduced by depency> are good examples. If your change is obvious, you may be able to omit
+  addressing this question.
+
+- **What side effects does this change have?**
+
+  This is the most important question to answer, as it can point out problems where you are making
+  too many changes in one commit or branch. One or two bullet points for related changes may be
+  okay, but five or six are likely indicators of a commit that is doing too many things.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Kittinun Vantasin
+Copyright (c) 2018 Kittinun Vantasin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes #409 

Adds:
- `CHANGELOG.md`: simply a link to the releases page as that's where the changelog is. This helps with tooling that automatically displays a changelog when it's present,
- `CODE_OF_CONDUCT.md`: a document indicating the community values, albeit a guideline and reference for contributors and interactions,
- `CONTRIBUTING.md`: guidelines and help for people who are or want to start contributing.

The latter two are picked up by GitHub and will show linked on the right when someone is contributing.