### PR TITLE
Update license year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Kittinun Vantasin
+Copyright (c) 2018 Kittinun Vantasin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Even though an MIT license is still valid if the copyright year is not correct and the copyright is not given or limited by the year, it's nice to have the current year as it was updated last year as well.