### PR TITLE
Add missing HTTP methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fuel
 
-[ ![Kotlin](https://img.shields.io/badge/Kotlin-1.2.51-blue.svg)](http://kotlinlang.org) [ ![jcenter](https://api.bintray.com/packages/kittinunf/maven/Fuel-Android/images/download.svg) ](https://bintray.com/kittinunf/maven/Fuel-Android/_latestVersion) [![Build Status](https://travis-ci.org/kittinunf/Fuel.svg?branch=master)](https://travis-ci.org/kittinunf/Fuel)
+[ ![Kotlin](https://img.shields.io/badge/Kotlin-1.2.51-blue.svg)](https://kotlinlang.org) [ ![jcenter](https://api.bintray.com/packages/kittinunf/maven/Fuel-Android/images/download.svg) ](https://bintray.com/kittinunf/maven/Fuel-Android/_latestVersion) [![Build Status](https://travis-ci.org/kittinunf/Fuel.svg?branch=master)](https://travis-ci.org/kittinunf/Fuel)
 [![Codecov](https://codecov.io/github/kittinunf/Fuel/coverage.svg?branch=master)](https://codecov.io/gh/kittinunf/Fuel)
 
 The easiest HTTP networking library for Kotlin/Android.
@@ -93,7 +93,7 @@ dependencies {
 * Kotlin
 ``` Kotlin
 //an extension over string (support GET, PUT, POST, DELETE with httpGet(), httpPut(), httpPost(), httpDelete())
-"http://httpbin.org/get".httpGet().responseString { request, response, result ->
+"https://httpbin.org/get".httpGet().responseString { request, response, result ->
   //do something with response
   when (result) {
     is Result.Failure -> {
@@ -106,9 +106,9 @@ dependencies {
 }
 
 //if we set baseURL beforehand, simply use relativePath
-FuelManager.instance.basePath = "http://httpbin.org"
+FuelManager.instance.basePath = "https://httpbin.org"
 "/get".httpGet().responseString { request, response, result ->
-    //make a GET to http://httpbin.org/get and do something with response
+    //make a GET to https://httpbin.org/get and do something with response
     val (data, error) = result
     if (error == null) {
         //do something when success
@@ -119,7 +119,7 @@ FuelManager.instance.basePath = "http://httpbin.org"
 
 //if you prefer this a little longer way, you can always do
 //get
-Fuel.get("http://httpbin.org/get").responseString { request, response, result ->
+Fuel.get("https://httpbin.org/get").responseString { request, response, result ->
 	//do something with response
 	result.fold({ d ->
 	    //do something with data
@@ -133,7 +133,7 @@ Fuel.get("http://httpbin.org/get").responseString { request, response, result ->
 * Java
 ``` Java
 //get
-Fuel.get("http://httpbin.org/get", params).responseString(new Handler<String>() {
+Fuel.get("https://httpbin.org/get", params).responseString(new Handler<String>() {
     @Override
     public void failure(Request request, Response response, FuelError error) {
     	//do something when it is failure
@@ -151,13 +151,13 @@ You can also wait for the response. It returns the same parameters as the async 
 
 * Kotlin
 ``` Kotlin
-val (request, response, result) = "http://httpbin.org/get".httpGet().responseString() // result is Result<String, FuelError>
+val (request, response, result) = "https://httpbin.org/get".httpGet().responseString() // result is Result<String, FuelError>
 ```
 
 * Java
 ``` Java
 try {
-    Triple<Request, Response, String> data = Fuel.get("http://www.google.com").responseString();
+    Triple<Request, Response, String> data = Fuel.get("https://www.google.com").responseString();
     Request request = data.getFirst();
     Response response = data.getSecond();
     Result<String,FuelError> text = data.getThird();
@@ -172,7 +172,7 @@ try {
 ### GET
 
 ``` Kotlin
-Fuel.get("http://httpbin.org/get").response { request, response, result ->
+Fuel.get("https://httpbin.org/get").response { request, response, result ->
     println(request)
     println(response)
     val (bytes, error) = result
@@ -187,7 +187,7 @@ Fuel.get("http://httpbin.org/get").response { request, response, result ->
 
 * [Result](https://github.com/kittinunf/Result) is a functional style data structure that represents data that contains result of *Success* or *Failure* but not both. It represents the result of an action that can be success (with result) or error.
 
-* Working with result is easy. You could [*fold*](https://github.com/kittinunf/Fuel/blob/master/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt#L324), [*destructure*](https://github.com/kittinunf/Fuel/blob/master/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt#L266) as because it is just a [data class](http://kotlinlang.org/docs/reference/data-classes.html) or do a simple ```when``` checking whether it is *Success* or *Failure*.
+* Working with result is easy. You could [*fold*](https://github.com/kittinunf/Fuel/blob/master/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt#L324), [*destructure*](https://github.com/kittinunf/Fuel/blob/master/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt#L266) as because it is just a [data class](https://kotlinlang.org/docs/reference/data-classes.html) or do a simple ```when``` checking whether it is *Success* or *Failure*.
 
 ### Response
 ``` Kotlin
@@ -216,44 +216,64 @@ fun <T> responseObject(deserializer: ResponseDeserializable<T>, handler: (Reques
 ### POST
 
 ``` Kotlin
-Fuel.post("http://httpbin.org/post").response { request, response, result ->
+Fuel.post("https://httpbin.org/post").response { request, response, result ->
 }
 
 //if you have body to post it manually
-Fuel.post("http://httpbin.org/post").jsonBody("{ \"foo\" : \"bar\" }").response { request, response, result ->
+Fuel.post("https://httpbin.org/post").jsonBody("{ \"foo\" : \"bar\" }").response { request, response, result ->
 }
 ```
 
 ### PUT
 
 ``` Kotlin
-Fuel.put("http://httpbin.org/put").response { request, response, result ->
+Fuel.put("https://httpbin.org/put").response { request, response, result ->
 }
 ```
 
 ### DELETE
 
 ``` Kotlin
-Fuel.delete("http://httpbin.org/delete").response { request, response, result ->
+Fuel.delete("https://httpbin.org/delete").response { request, response, result ->
 }
 ```
 
 ### HEAD
 
 ``` Kotlin
-Fuel.head("http://httpbin.org/get").response { request, response, result ->
+Fuel.head("https://httpbin.org/get").response { request, response, result ->
    // request body should be empty.
 }
 ```
 
 ### PATCH
-* The default `client` is [`HttpClient`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt) which is a thin wrapper over [`java.net.HttpUrlConnnection`](http://developer.android.com/reference/java/net/HttpURLConnection.html). [`java.net.HttpUrlConnnection`](http://developer.android.com/reference/java/net/HttpURLConnection.html) does not support a [`PATCH`](http://download.java.net/jdk7/archive/b123/docs/api/java/net/HttpURLConnection.html#setRequestMethod(java.lang.String)) method. [`HttpClient`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt) converts `PATCH` requests to a `POST` request and adds a `X-HTTP-Method-Override: PATCH` header. While this is a semi-standard industry practice not all APIs are configured to accept this header by default.
+* The default `client` is [`HttpClient`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt) which is a thin wrapper over [`java.net.HttpUrlConnnection`](https://developer.android.com/reference/java/net/HttpURLConnection.html). [`java.net.HttpUrlConnnection`](https://developer.android.com/reference/java/net/HttpURLConnection.html) does not support a [`PATCH`](https://download.java.net/jdk7/archive/b123/docs/api/java/net/HttpURLConnection.html#setRequestMethod(java.lang.String)) method. [`HttpClient`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt) converts `PATCH` requests to a `POST` request and adds a `X-HTTP-Method-Override: PATCH` header. While this is a semi-standard industry practice not all APIs are configured to accept this header by default.
 
 ``` Kotlin
-Fuel.patch("http://httpbin.org/patch").response { request, response, result ->
+Fuel.patch("https://httpbin.org/patch").response { request, response, result ->
    // request body should be empty.
 }
 ```
+
+### CONNECT
+Connect is not supported by the Java JVM via the regular HTTP clients, and is therefore not supported.
+
+### OPTIONS
+There are no convenience methods for making an OPTIONS request, but you can still make one directly:
+
+``` Kotlin
+Fuel.request(Method.OPTIONS, "https://httpbin.org/anything").response { request, response, result ->
+}
+```
+
+### TRACE
+There are no convenience methods for making an TRACE request, but you can still make one directly:
+
+``` Kotlin
+Fuel.request(Method.TRACE, "https://httpbin.org/anything").response { request, response, result ->
+}
+```
+
 
 ### Debug Logging
 * Use `toString()` method to Log (request|response)
@@ -265,14 +285,14 @@ Log.d("log", request.toString())
 ```
 //print and header detail
 //request
---> GET (http://httpbin.org/get?key=value)
+--> GET (https://httpbin.org/get?key=value)
     Body : (empty)
     Headers : (2)
     Accept-Encoding : compress;q=0.5, gzip;q=1.0
     Device : Android
 
 //response
-<-- 200 (http://httpbin.org/get?key=value)
+<-- 200 (https://httpbin.org/get?key=value)
 ```
 
 * Also support cUrl string to Log request, make it very easy to cUrl on command line
@@ -283,7 +303,7 @@ Log.d("cUrl log", request.cUrlString())
 
 ``` Bash
 //print
-curl -i -X POST -d "foo=foo&bar=bar&key=value" -H "Accept-Encoding:compress;q=0.5, gzip;q=1.0" -H "Device:Android" -H "Content-Type:application/x-www-form-urlencoded" "http://httpbin.org/post"
+curl -i -X POST -d "foo=foo&bar=bar&key=value" -H "Accept-Encoding:compress;q=0.5, gzip;q=1.0" -H "Device:Android" -H "Content-Type:application/x-www-form-urlencoded" "https://httpbin.org/post"
 ```
 
 ### Parameter Support
@@ -291,31 +311,31 @@ curl -i -X POST -d "foo=foo&bar=bar&key=value" -H "Accept-Encoding:compress;q=0.
 * URL encoded style for GET & DELETE request
 
 ``` Kotlin
-Fuel.get("http://httpbin.org/get", listOf("foo" to "foo", "bar" to "bar")).response { request, response, result -> {
-    //resolve to http://httpbin.org/get?foo=foo&bar=bar
+Fuel.get("https://httpbin.org/get", listOf("foo" to "foo", "bar" to "bar")).response { request, response, result -> {
+    //resolve to https://httpbin.org/get?foo=foo&bar=bar
 }
 
-Fuel.delete("http://httpbin.org/delete", listOf("foo" to "foo", "bar" to "bar")).response { request, response, result ->
-    //resolve to http://httpbin.org/delete?foo=foo&bar=bar
+Fuel.delete("https://httpbin.org/delete", listOf("foo" to "foo", "bar" to "bar")).response { request, response, result ->
+    //resolve to https://httpbin.org/delete?foo=foo&bar=bar
 }
 ```
 
 * Array support for GET requests
 
 ``` Kotlin
-Fuel.get("http://httpbin.org/get", listOf("foo" to "foo", "dwarf" to  arrayOf("grumpy","happy","sleepy","dopey"))).response { request, response, result -> {
-    //resolve to http://httpbin.org/get?foo=foo&dwarf[]=grumpy&dwarf[]=happy&dwarf[]=sleepy&dwarf[]=dopey
+Fuel.get("https://httpbin.org/get", listOf("foo" to "foo", "dwarf" to  arrayOf("grumpy","happy","sleepy","dopey"))).response { request, response, result -> {
+    //resolve to https://httpbin.org/get?foo=foo&dwarf[]=grumpy&dwarf[]=happy&dwarf[]=sleepy&dwarf[]=dopey
 }
 ```
 
 * Support x-www-form-urlencoded for PUT & POST
 
 ``` Kotlin
-Fuel.post("http://httpbin.org/post", listOf("foo" to "foo", "bar" to "bar")).response { request, response, result ->
+Fuel.post("https://httpbin.org/post", listOf("foo" to "foo", "bar" to "bar")).response { request, response, result ->
     //http body includes foo=foo&bar=bar
 }
 
-Fuel.put("http://httpbin.org/put", listOf("foo" to "foo", "bar" to "bar")).response { request, response, result ->
+Fuel.put("https://httpbin.org/put", listOf("foo" to "foo", "bar" to "bar")).response { request, response, result ->
     //http body includes foo=foo&bar=bar
 }
 ```
@@ -329,14 +349,14 @@ Default read timeout for a request is 15000 milliseconds.
 val timeout = 5000 // 5000 milliseconds = 5 seconds.
 val timeoutRead = 60000 // 60000 milliseconds = 1 minute.
 
-"http://httpbin.org/get".httpGet().timeout(timeout).timeoutRead(timeoutRead).responseString { request, response, result -> }
+"https://httpbin.org/get".httpGet().timeout(timeout).timeoutRead(timeoutRead).responseString { request, response, result -> }
 ```
 
 * Java
 ``` Java
 int timeout = 5000 // 5000 milliseconds = 5 seconds.
 int timeoutRead = 60000 // 60000 milliseconds = 1 minute.
-Fuel.get("http://httpbin.org/get", params).timeout(timeout).timeoutRead(timeoutRead).responseString(new Handler<String>() {
+Fuel.get("https://httpbin.org/get", params).timeout(timeout).timeoutRead(timeoutRead).responseString(new Handler<String>() {
     @Override
     public void failure(Request request, Response response, FuelError error) {
     	//do something when it is failure
@@ -351,13 +371,13 @@ Fuel.get("http://httpbin.org/get", params).timeout(timeout).timeoutRead(timeoutR
 
 ### Download with or without progress handler
 ``` Kotlin
-Fuel.download("http://httpbin.org/bytes/32768").destination { response, url ->
+Fuel.download("https://httpbin.org/bytes/32768").destination { response, url ->
     File.createTempFile("temp", ".tmp")
 }.response { req, res, result ->
 
 }
 
-Fuel.download("http://httpbin.org/bytes/32768").destination { response, url ->
+Fuel.download("https://httpbin.org/bytes/32768").destination { response, url ->
     File.createTempFile("temp", ".tmp")
 }.progress { readBytes, totalBytes ->
     val progress = readBytes.toFloat() / totalBytes.toFloat()
@@ -378,7 +398,7 @@ Fuel.upload("/post").source { request, url ->
 Fuel.upload("/put", Method.PUT).source { request, url ->
     File.createTempFile("temp", ".tmp");
 }.responseString { request, response, result ->
-    // calls to http://example.com/api/put with PUT
+    // calls to https://example.com/api/put with PUT
 
 }
 
@@ -434,7 +454,7 @@ Fuel.upload("/post").blob { request, url ->
 val username = "username"
 val password = "abcd1234"
 
-Fuel.get("http://httpbin.org/basic-auth/$user/$password").authenticate(username, password).response { request, response, result ->
+Fuel.get("https://httpbin.org/basic-auth/$user/$password").authenticate(username, password).response { request, response, result ->
 }
 ```
 
@@ -446,7 +466,7 @@ Fuel.get("http://httpbin.org/basic-auth/$user/$password").authenticate(username,
 
 * If one wants to cancel on-going request, one could call `cancel` on the request object
 ``` Kotlin
-val request = Fuel.get("http://httpbin.org/get").response { request, response, result ->
+val request = Fuel.get("https://httpbin.org/get").response { request, response, result ->
     // if request is cancelled successfully, response callback will not be called. Interrupt callback (if provided) will be called instead
 }
 
@@ -456,7 +476,7 @@ request.cancel() //this will cancel on-going request
 
 * Also, interrupt request can be further processed with interrupt callback
 ``` Kotlin
-val request = Fuel.get("http://httpbin.org/get").interrupt { request ->
+val request = Fuel.get("https://httpbin.org/get").interrupt { request ->
     println("${request.url} was interrupted and cancelled")
 }.response { request, response, result ->
     // if request is cancelled successfully, response callback will not be called. Interrupt callback (if provided) will be called instead
@@ -485,7 +505,7 @@ data class User(val firstName: String = "",
 }
 
 //Use httpGet extension
-"http://www.example.com/user/1".httpGet().responseObject(User.Deserializer()) { req, res, result ->
+"https://www.example.com/user/1".httpGet().responseObject(User.Deserializer()) { req, res, result ->
     //result is of type Result<User, Exception>
     val (user, err) = result
 
@@ -576,7 +596,7 @@ Fuel.get("/get").response { request, response, result ->
 }
 ```
 
-* `client` is a raw HTTP client driver. Generally, it is responsible to make [`Request`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/fuel/core/Request.kt) into [`Response`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/fuel/core/Response.kt). Default is [`HttpClient`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/fuel/toolbox/HttpClient.kt) which is a thin wrapper over [`java.net.HttpUrlConnnection`](http://developer.android.com/reference/java/net/HttpURLConnection.html). You could use any httpClient of your choice by conforming to [`client`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Client.kt) protocol, and set back to `FuelManager.instance` to kick off the effect.
+* `client` is a raw HTTP client driver. Generally, it is responsible to make [`Request`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/fuel/core/Request.kt) into [`Response`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/fuel/core/Response.kt). Default is [`HttpClient`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/fuel/toolbox/HttpClient.kt) which is a thin wrapper over [`java.net.HttpUrlConnnection`](https://developer.android.com/reference/java/net/HttpURLConnection.html). You could use any httpClient of your choice by conforming to [`client`](https://github.com/kittinunf/Fuel/blob/master/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Client.kt) protocol, and set back to `FuelManager.instance` to kick off the effect.
 
 * `keyStore` is configurable by user. By default it is `null`.
 
@@ -610,7 +630,7 @@ inline fun <reified T> DbResponseInterceptor() =
         }
 
 manager.addResponseInterceptor(DBResponseInterceptor<Dog>)
-manager.request(Method.GET, "http://www.example.com/api/dog/1").response() // Db interceptor will be called to intercept data and save into Database of your choice
+manager.request(Method.GET, "https://www.example.com/api/dog/1").response() // Db interceptor will be called to intercept data and save into Database of your choice
 ```
 
 ### Test mode
@@ -630,7 +650,7 @@ In order to disable test mode, just call `Fuel.regularMode()`
 * Fuel supports [RxJava](https://github.com/ReactiveX/RxJava) right off the box.
 
 ``` Kotlin
-"http://www.example.com/photos/1".httpGet().rx_object(Photo.Deserializer()).subscribe {
+"https://www.example.com/photos/1".httpGet().rx_object(Photo.Deserializer()).subscribe {
 	//do something
 }
 ```
@@ -798,4 +818,4 @@ Fuel is brought to you by [contributors](https://github.com/kittinunf/Fuel/graph
 
 ## Licenses
 
-Fuel is released under the [MIT](http://opensource.org/licenses/MIT) license.
+Fuel is released under the [MIT](https://opensource.org/licenses/MIT) license.

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/Fuel.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/Fuel.kt
@@ -115,13 +115,36 @@ class Fuel {
         fun head(convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
                 request(Method.HEAD, convertible, parameters)
 
-        //request
-        private fun request(method: Method, path: String, parameters: List<Pair<String, Any?>>? = null): Request =
+        /**
+         * Convenience method to make a request
+         *
+         * @see Method
+         *
+         * @param method [Method] the HTTP method to make the request with
+         * @param path [String] the absolute url or relative path (to FuelManager.instance.basePath)
+         * @param parameters [List<Pair<String, Any?>>?] list of parameters
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun request(method: Method, path: String, parameters: List<Pair<String, Any?>>? = null): Request =
                 FuelManager.instance.request(method, path, parameters)
 
-        private fun request(method: Method, convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
+        /**
+         * Convenience method to make a request from a [com.github.kittinunf.fuel.Fuel.PathStringConvertible}
+         *
+         * @see Method
+         * @see Fuel.request(Method, String, List<Pair<String, Any?>>?)
+         *
+         * @param convertible [PathStringConvertible]
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun request(method: Method, convertible: PathStringConvertible, parameters: List<Pair<String, Any?>>? = null): Request =
                 request(method, convertible.path, parameters)
 
+        /**
+         * Convenience method to make a request from a [com.github.kittinunf.fuel.Fuel.RequestConvertible}
+         */
         @JvmStatic
         fun request(convertible: RequestConvertible): Request = FuelManager.instance.request(convertible)
     }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Method.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Method.kt
@@ -1,11 +1,21 @@
 package com.github.kittinunf.fuel.core
 
+/**
+ * HTTP method as defined by RFC 7231 and 5489
+ *
+ * @see https://tools.ietf.org/html/rfc7231
+ * @see https://tools.ietf.org/html/rfc5789
+ *
+ * CONNECT is not included as it's not supported by the java jvm (java.net.ProtocolException).
+ */
 enum class Method(val value: String) {
     GET("GET"),
+    HEAD("HEAD"),
     POST("POST"),
     PUT("PUT"),
     DELETE("DELETE"),
+    OPTIONS("OPTIONS"),
+    TRACE("TRACE"),
     PATCH("PATCH"),
-    HEAD("HEAD")
 }
 

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -95,7 +95,7 @@ internal class HttpClient(private val proxy: Proxy? = null) : Client {
     }
 
     private fun setDoOutput(connection: HttpURLConnection, method: Method) = when (method) {
-        Method.GET, Method.HEAD -> connection.doOutput = false
+        Method.GET, Method.HEAD, Method.OPTIONS, Method.TRACE -> connection.doOutput = false
         Method.DELETE, Method.POST, Method.PUT, Method.PATCH -> connection.doOutput = true
     }
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -26,10 +26,7 @@ class RequestTest : BaseTestCase() {
 
     enum class HttpsBin(relativePath: String) : Fuel.PathStringConvertible {
         USER_AGENT("user-agent"),
-        POST("post"),
-        PUT("put"),
-        PATCH("patch"),
-        DELETE("delete");
+        ANYTHING("anything");
 
         override val path = "https://httpbin.org/$relativePath"
     }
@@ -539,6 +536,65 @@ class RequestTest : BaseTestCase() {
         assertThat(response?.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
 
         assertThat(string, equalTo(""))
+    }
+
+    @Test
+    fun httpOptionsRequest() {
+        var request: Request? = null
+        var response: Response? = null
+        var data: Any? = null
+        var error: FuelError? = null
+
+        manager.request(Method.OPTIONS, HttpsBin.ANYTHING).responseString { req, res, result ->
+            request = req
+            response = res
+
+            val (d, err) = result
+            data = d
+            error = err
+        }
+
+        val string = data as String
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        assertThat(response?.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+
+        assertThat(string, equalTo(""))
+    }
+
+    @Test
+    fun httpTraceRequest() {
+        var request: Request? = null
+        var response: Response? = null
+        var data: Any? = null
+        var error: FuelError? = null
+
+        manager.request(Method.TRACE, HttpsBin.ANYTHING).responseString { req, res, result ->
+            request = req
+            response = res
+
+            val (d, err) = result
+            data = d
+            error = err
+        }
+
+        assertThat(request, notNullValue())
+        assertThat(response, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(data, notNullValue())
+
+        val result = JSONObject(data as String)
+
+        assertThat(response?.statusCode, isEqualTo(HttpURLConnection.HTTP_OK))
+
+        assertThat(result.get("headers"), notNullValue())
+        assertEquals(result.get("method"), "TRACE")
+        assertThat(result.get("origin"), notNullValue())
+        assertThat(result.get("url"), notNullValue())
     }
 
     @Test


### PR DESCRIPTION
## Description

TRACE and OPTIONS, albeit not commonly used, are valid HTTP methods. This adds support for making TRACE and OPTIONS requests without adding convenience methods as they are not commonly used (in Java/Kotlin/Android projects).

Additionally the documentation now has HTTPS everywhere, as all the linked domains support HTTPS.

## Type of change

Check all that apply

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (change which changes the current internal or external interface)
- [X] This change requires a documentation update

## How Has This Been Tested?

Tests for the new methods have been added

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new compiler warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
