### PR TITLE
Allow custom adapters in moshiDeserializerOf() for Moshi

### DIFF
--- a/fuel-moshi/src/main/kotlin/com/github/kittinunf/fuel/moshi/FuelMoshi.kt
+++ b/fuel-moshi/src/main/kotlin/com/github/kittinunf/fuel/moshi/FuelMoshi.kt
@@ -20,3 +20,8 @@ inline fun <reified T : Any> moshiDeserializerOf() = object : ResponseDeserializ
                     .adapter(T::class.java)
                     .fromJson(content)
 }
+
+inline fun <reified T : Any> moshiDeserializerOf(adapter: JsonAdapter<T>) = object : ResponseDeserializable<T> {
+    override fun deserialize(content: String): T? =
+            adapter.fromJson(content)
+}


### PR DESCRIPTION
## Description

This adds `moshiDeserializerOf(some_adapter)` to the Moshi integration of this library.

Use case: https://github.com/square/moshi#parse-json-arrays.

## Type of change

Check all that apply

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have the very same method in a local project and it works fine.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
