### PR TITLE
Replace buildscript with plugin DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,26 +7,14 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-buildscript {
-    repositories {
-        mavenCentral()
-        jcenter()
-        google()
-        maven(url = "https://dl.bintray.com/kotlin/kotlin-dev")
-        maven(url = "https://kotlin.bintray.com/kotlinx")
-        maven(url = "http://dl.bintray.com/kotlin/kotlin-eap")
-    }
-
-    dependencies {
-        classpath(Plugins.android)
-        classpath(Plugins.jacocoAndroid)
-        classpath(Plugins.bintray)
-        classpath(Plugins.kotlin)
-        classpath(Plugins.serialization)
-    }
+plugins {
+    java
+    kotlin("jvm") version Versions.kotlinVersion apply false
+    id(Plugins.androidLib) version Versions.androidVersion apply false
+    id(Plugins.jacocoAndroid) version Versions.jacocoAndroidVersion apply false
+    id(Plugins.bintrayRelease) version Versions.bintrayReleaseVersion apply false
+    id(Plugins.serialization) version Versions.kotlinVersion apply false
 }
-
-plugins { java }
 
 allprojects {
     repositories {
@@ -82,10 +70,10 @@ subprojects {
 
     if (isAndroidModule) {
         apply {
-            plugin("com.android.library")
-            plugin("kotlin-android")
-            plugin("kotlin-android-extensions")
-            plugin("jacoco-android")
+            plugin(Plugins.androidLib)
+            plugin(Plugins.kotlinAndroid)
+            plugin(Plugins.kotlinAndroidExtensions)
+            plugin(Plugins.jacocoAndroid)
         }
 
         configure<BaseExtension> {
@@ -135,7 +123,7 @@ subprojects {
 
     if (!isSample) {
         apply {
-            plugin("com.novoda.bintray-release")
+            plugin(Plugins.bintrayRelease)
         }
 
         configure<PublishExtension> {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,7 +14,7 @@ object Dependencies {
     val kotlinCoroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.kotlinCoroutinesVersion}"
     val kotlinCoroutinesJvm = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutinesVersion}"
     val kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlinVersion}"
-    val serialization = "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.8.2-rc13"
+    val serialization = "org.jetbrains.kotlinx:kotlinx-serialization-runtime:${Versions.kotlinxSerialization}"
     val mockServer = "org.mock-server:mockserver-netty:${Versions.mockServerVersion}"
     val moshi = "com.squareup.moshi:moshi:${Versions.moshiVersion}"
     val result = "com.github.kittinunf.result:result:${Versions.resultVersion}"

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -1,7 +1,9 @@
 object Plugins {
-    const val android = "com.android.tools.build:gradle:3.1.3"
-    const val jacocoAndroid = "com.dicedmelon.gradle:jacoco-android:0.1.3"
-    const val bintray = "com.novoda:bintray-release:0.8.0"
-    const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlinVersion}"
-    const val serialization = "org.jetbrains.kotlin:kotlin-serialization:${Versions.kotlinVersion}"
+    const val kotlinJvm = "org.jetbrains.kotlin.jvm"
+    const val kotlinAndroid = "kotlin-android"
+    const val kotlinAndroidExtensions = "kotlin-android-extensions"
+    const val androidLib = "com.android.library"
+    const val jacocoAndroid = "jacoco-android"
+    const val bintrayRelease = "com.novoda.bintray-release"
+    const val serialization = "kotlinx-serialization"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,13 +7,18 @@ object Versions {
     const val resultVersion = "1.6.0"
     const val jsonVersion = "20170516"
 
+    // Plugin Versions
+    const val androidVersion = "3.1.3"
+    const val jacocoAndroidVersion = "0.1.3"
+    const val bintrayReleaseVersion = "0.8.0"
+
     // Modules dependencies
     const val androidArchVersion = "1.1.1"
     const val forgeVersion = "0.3.0"
     const val gsonVersion = "2.8.2"
     const val jacksonVersion = "2.9.6"
     const val kotlinCoroutinesVersion = "0.30.1-eap13"
-    const val kotlinxSerialization = "0.6.2"
+    const val kotlinxSerialization = "0.8.0-rc13"
     const val moshiVersion = "1.6.0"
     const val reactorVersion = "3.2.0.M4"
     const val rxjavaVersion = "2.1.13"

--- a/fuel-kotlinx-serialization/build.gradle.kts
+++ b/fuel-kotlinx-serialization/build.gradle.kts
@@ -1,7 +1,6 @@
-plugins { java }
-
-apply {
-    plugin("kotlinx-serialization")
+plugins {
+    java
+    id(Plugins.serialization)
 }
 
 repositories {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,28 @@ pluginManagement {
     repositories {
         maven(url = "http://dl.bintray.com/kotlin/kotlin-eap")
         mavenCentral()
+        jcenter()
+        google()
         maven(url = "https://plugins.gradle.org/m2/")
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == Plugins.kotlinJvm) {
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:${requested.version}")
+            }
+            if(requested.id.id == Plugins.androidLib) {
+                useModule("com.android.tools.build:gradle:${requested.version}")
+            }
+            if(requested.id.id == Plugins.jacocoAndroid) {
+                useModule("com.dicedmelon.gradle:jacoco-android:${requested.version}")
+            }
+            if(requested.id.id == Plugins.bintrayRelease) {
+                useModule("com.novoda:bintray-release:${requested.version}")
+            }
+            if(requested.id.id == Plugins.serialization) {
+                useModule("org.jetbrains.kotlin:kotlin-serialization:${requested.version}")
+            }
+        }
     }
 }
 include(":fuel")


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

Replaced `buildscript` block with `plugins`
this will allow gradle to `Optimize the loading and reuse of plugin classes.` (at least according to their [documentation](https://docs.gradle.org/current/userguide/plugins.html#plugins_dsl_limitations))

IT should be discussed where versions and ids should be defined,
in theory plugins could also be applied as extension values somewhere in `buildSrc`

I organized it i na way that loads potentially faster and makes the most sense to me for now

## Type of change

Check all that apply

- [x] Refactoring build script (a change which changes the current internal or external interface)

## How Has This Been Tested?

This should **NOT** affect any tests or the module structure, just reload the gradle nature of the project in idea as usual

## Checklist:

- [x] My changes generate no new compiler warnings
