### PR TITLE
Replace Content-Type when jsonBody is called

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -146,7 +146,7 @@ class Request(
     fun body(body: String, charset: Charset = Charsets.UTF_8): Request = body(body.toByteArray(charset))
 
     fun jsonBody(body: String, charset: Charset = Charsets.UTF_8): Request {
-        header("content-type" to "application/json")
+        headers["Content-Type"] = "application/json"
         return body(body, charset)
     }
 

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/RequestTest.kt
@@ -270,7 +270,7 @@ class RequestTest : MockHttpTestCase() {
     fun httpPostRequestWithBody() {
         val foo = "foo"
         val bar = "bar"
-        val body = "{ $foo : $bar }"
+        val body = "{ $foo: $bar }"
 
         // Reflect encodes the body as a string, and gives back the body as a property of the body
         //  therefore the outer body here is the ey and the inner string is the actual body
@@ -289,6 +289,7 @@ class RequestTest : MockHttpTestCase() {
         val string = data as String
 
         assertThat(request, notNullValue())
+        assertThat(request.httpHeaders["Content-Type"], equalTo("application/json"))
         assertThat(response, notNullValue())
         assertThat(error, nullValue())
         assertThat(data, notNullValue())


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

Ensures that the default Content-Type of the request gets replaced instead of appending to the list or adding to a different header when `jsonBody` is called.

eventually case insensitive headers might be useful

<!-- Include a summary of the change and which [issue](https://github.com/kittinunf/Fuel/issues)
this fixes. Also, include relevant motivation and context. List any dependencies
that are required for this change and why they are necessary. -->

Fixes #473

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)

## How Has This Been Tested?

In case you did not include tests describe why you and how you have verified the
changes, with instructions so we can reproduce. If you have added comprehensive
tests for your changes, you may omit this section.

## Checklist:

- [x] New and existing unit tests pass locally with my changes
