### PR TITLE
Bump min SDk (Android) and JRE (Java)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The easiest HTTP networking library for Kotlin/Android.
 ### Dependency - fuel-android
 
 * [Android SDK](https://developer.android.com/studio/index.html) - Android SDK
+* Min SDK: 19 
 
 ### Dependency - fuel-livedata
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,8 +48,8 @@ subprojects {
         }
 
         configure<JavaPluginConvention> {
-            sourceCompatibility = JavaVersion.VERSION_1_6
-            targetCompatibility = JavaVersion.VERSION_1_6
+            sourceCompatibility = JavaVersion.VERSION_1_7
+            targetCompatibility = JavaVersion.VERSION_1_7
 
             sourceSets {
                 getByName("main").java.srcDirs("src/main/kotlin")
@@ -90,8 +90,8 @@ subprojects {
             }
 
             compileOptions {
-                setSourceCompatibility(JavaVersion.VERSION_1_6)
-                setTargetCompatibility(JavaVersion.VERSION_1_6)
+                setSourceCompatibility(JavaVersion.VERSION_1_7)
+                setTargetCompatibility(JavaVersion.VERSION_1_7)
             }
 
             buildTypes {

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -3,7 +3,7 @@ object Fuel {
     const val publishVersion = "1.16.0"
 
     const val compileSdkVersion = 27
-    const val minSdkVersion = 14
+    const val minSdkVersion = 19
 }
 
 // Core dependencies


### PR DESCRIPTION
## Description

- *Bump the Java Compatibility to 1.7*
Java 1.6 is EOL, no more [security] updates, nor security updates. We should move to 1.8 as soon as possible, but this intermediary gives us time to update the current code with small increments.

- *Bump min sdk to 19*
https://twitter.com/minsdkversion?lang=en says 21 in April 2018, and 19 on november 2016. A bump from 14 tot 19 will only lose a few percents and it's not worth the hassle, according to https://developer.android.com/about/dashboards/.

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [X] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation, if necessary
- [] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
