### PR TITLE
support chunked content encoding

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -171,6 +171,8 @@ internal class HttpClient(
             "gzip" -> GZIPInputStream(stream)
             "deflate" -> InflaterInputStream(stream)
             "identity" -> stream
+            // the underlying HttpClient handles chunked, but does not remove the Transfer-Encoding Header
+            "chunked" -> stream
             "" -> stream
             else -> throw UnsupportedOperationException("Decoding $encoding is not supported. $SUPPORTED_DECODING are.")
         }


### PR DESCRIPTION
## Description

The underlying HttpClient already handles the chunked `Transfer-Encoding` but does not remove it from the headers, so it can be handled like empty `Transfer-Encoding`

Sadly i cannot add a mock test for this, since the mock client seems to be unable to create chunked responses

Fixes #495

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The fix is tested with matterbridge message stream endpoint
https://github.com/42wim/matterbridge/blob/master/bridge/api/api.go#L102

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
