### PR TITLE
Add option to pass in a Serializer to kotlinxSerializerOf without propagating @ImplicitReflectionSerializer

### DIFF
--- a/fuel-kotlinx-serialization/src/main/kotlin/com/github/kittinunf/fuel/serialization/FuelSerialization.kt
+++ b/fuel-kotlinx-serialization/src/main/kotlin/com/github/kittinunf/fuel/serialization/FuelSerialization.kt
@@ -14,28 +14,44 @@ import kotlinx.serialization.ImplicitReflectionSerializer
 import kotlinx.serialization.json.JSON
 import kotlinx.serialization.serializer
 
-@ImplicitReflectionSerializer
 inline fun <reified T : Any> Request.responseObject(
-    loader: DeserializationStrategy<T> = T::class.serializer(),
+    loader: DeserializationStrategy<T>,
     json: JSON = JSON.plain,
     noinline deserializer: (Request, Response, Result<T, FuelError>) -> Unit
 ) = response(kotlinxDeserializerOf(loader, json), deserializer)
 
 @ImplicitReflectionSerializer
 inline fun <reified T : Any> Request.responseObject(
+    json: JSON = JSON.plain,
+    noinline deserializer: (Request, Response, Result<T, FuelError>) -> Unit
+) = responseObject(T::class.serializer(), json, deserializer)
+
+inline fun <reified T : Any> Request.responseObject(
     deserializer: Handler<T>,
-    loader: DeserializationStrategy<T> = T::class.serializer(),
+    loader: DeserializationStrategy<T>,
     json: JSON = JSON.plain
 ) = response(kotlinxDeserializerOf(loader, json), deserializer)
 
 @ImplicitReflectionSerializer
 inline fun <reified T : Any> Request.responseObject(
-    loader: DeserializationStrategy<T> = T::class.serializer(),
+    deserializer: Handler<T>,
+    json: JSON = JSON.plain
+) = responseObject(deserializer, T::class.serializer(), json)
+
+inline fun <reified T : Any> Request.responseObject(
+    loader: DeserializationStrategy<T>,
     json: JSON = JSON.plain
 ) = response(kotlinxDeserializerOf(loader, json))
 
 @ImplicitReflectionSerializer
-inline fun <reified T : Any> kotlinxDeserializerOf(loader: DeserializationStrategy<T> = T::class.serializer(), json: JSON = JSON.plain) = object : ResponseDeserializable<T> {
+inline fun <reified T : Any> Request.responseObject(
+    json: JSON = JSON.plain
+) = responseObject(T::class.serializer(), json)
+
+inline fun <reified T : Any> kotlinxDeserializerOf(
+    loader: DeserializationStrategy<T>,
+    json: JSON = JSON.plain
+) = object : ResponseDeserializable<T> {
     override fun deserialize(content: String): T? = json.parse(loader, content)
     override fun deserialize(reader: Reader): T? = deserialize(reader.readText())
     override fun deserialize(bytes: ByteArray): T? = deserialize(String(bytes))
@@ -46,3 +62,8 @@ inline fun <reified T : Any> kotlinxDeserializerOf(loader: DeserializationStrate
         }
     }
 }
+
+@ImplicitReflectionSerializer
+inline fun <reified T : Any> kotlinxDeserializerOf(
+    json: JSON = JSON.plain
+) = kotlinxDeserializerOf(T::class.serializer(), json)


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

this avoids infecting user code with `@ImplicitReflectionSerializer` when a DeserializationStrategy is passed by the user

annoyingly the annotation requires to create extra functions

<!-- Fixes #0
Fixes #0 -->

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In case you did not include tests describe why you and how you have verified the
changes, with instructions so we can reproduce. If you have added comprehensive
tests for your changes, you may omit this section.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
