### PR TITLE
Unify Request/Response toString

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Response.kt
@@ -48,16 +48,16 @@ data class Response(
         val contentType = guessContentType()
 
         val bodyString = when {
-            body.isEmpty() -> "empty"
-            body.isConsumed() -> "consumed"
+            body.isEmpty() -> "(empty)"
+            body.isConsumed() -> "(consumed)"
             else -> processBody(contentType, body.toByteArray())
         }
 
         return buildString {
-            appendln("<-- $statusCode ($url)")
+            appendln("<-- $statusCode $url")
             appendln("Response : $responseMessage")
             appendln("Length : $contentLength")
-            appendln("Body : ($bodyString)")
+            appendln("Body : $bodyString")
             appendln("Headers : (${headers.size})")
 
             val appendHeaderWithValue = { key: String, value: String -> appendln("$key : $value") }
@@ -79,7 +79,7 @@ data class Response(
         return if (contentType.isNotEmpty() &&
                 (contentType.contains("image/") ||
                         contentType.contains("application/octet-stream"))) {
-            "$contentLength bytes of ${guessContentType(headers)}"
+            "($contentLength bytes of ${guessContentType(headers)})"
         } else if (bodyData.isNotEmpty()) {
             String(bodyData)
         } else {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DefaultRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DefaultRequest.kt
@@ -373,8 +373,8 @@ data class DefaultRequest(
         }
 
         appendln("--> $method $url")
-        appendln("\"Body : $bodyString\"")
-        appendln("\"Headers : (${headers.size})\"")
+        appendln("Body : $bodyString")
+        appendln("Headers : (${headers.size})")
 
         val appendHeaderWithValue = { key: String, value: String -> appendln("$key : $value") }
         headers.transformIterate(appendHeaderWithValue)

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/requests/DefaultRequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/requests/DefaultRequestTest.kt
@@ -1,0 +1,25 @@
+package com.github.kittinunf.fuel.core.requests
+
+import com.github.kittinunf.fuel.core.Headers
+import com.github.kittinunf.fuel.core.Method
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import java.net.URL
+
+class DefaultRequestTest {
+
+    @Test
+    fun requestToStringIncludesMethod() {
+        val request = DefaultRequest(
+                Method.POST,
+                url = URL("http://httpbin.org/post"),
+                headers = Headers.from("Content-Type" to "text/html"),
+                parameters = listOf("foo" to "xxx")
+        ).body("it's a body")
+
+        assertEquals(request.toString(), "--> POST http://httpbin.org/post\n" +
+                "Body : it's a body\n" +
+                "Headers : (1)\n" +
+                "Content-Type : text/html\n")
+    }
+}


### PR DESCRIPTION
Make body parens consistent (don't include parens when body isn't empty)
Remove un-needed quotes
Add Method to request toString

## Description

The `toString` of Request/Response is a recommended tool for debugging. However there are some inconsistencies. The readme even shows the http method but it wasn't actually being written out.

## Type of change

Check all that apply

- [X] Bug fix (a non-breaking change which fixes an issue)

(Unless users are parsing the `toString` currently, which they shouldn't)

## How Has This Been Tested?

Added unit test

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new compiler warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

