### PR TITLE
As per the RFCs, 307 and 308 should re-use the body

### DIFF
--- a/fuel/README.md
+++ b/fuel/README.md
@@ -161,7 +161,7 @@ All the `String` extensions listed above, as well as the `Fuel` and `FuelManager
     ```
 
 ### Adding `Request` body
-Bodies are formed from generic streams, but there are helpers to set it from values that can be turned into streams. It is important to know that, by default, the streams are **NOT** read into memory until the `Request` is sent.
+Bodies are formed from generic streams, but there are helpers to set it from values that can be turned into streams. It is important to know that, by default, the streams are **NOT** read into memory until the `Request` is sent. However, if you pass in an in-memory value such as a `ByteArray` or `String`, `Fuel` uses `RepeatableBody`, which are kept into memory until the `Request` is dereferenced.
 
 When you're using the default `Client`, bodies are supported for:
 - `POST`
@@ -264,6 +264,11 @@ Fuel.post("https://httpbin.org/post")
  * Content-Type : text/plain
  */
 ```
+
+#### Using automatic body redirection
+The default redirection interceptor only forwards `RepeatableBody`, and only if the status code is 307 or 308, as per the RFCs. In order to use a `RepeatableBody`, pass in a `String` or `ByteArray` as body, or explicitely set `repeatable = true` for the `fun body(...)` call.
+
+**NOTE** this loads the _entire_ body into memory, and therefore is not suited for large bodies.
 
 ### Adding `Headers`
 There are many ways to set, overwrite, remove and append headers. For your convenience, internally used and common header names are attached to the `Headers` companion and can be accessed (e.g. `Headers.CONTENT_TYPE`, `Headers.ACCEPT`, ...).

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Request.kt
@@ -390,10 +390,11 @@ interface Request : RequestFactory.RequestConvertible {
      * @param openStream [BodySource] a function that yields a stream
      * @param calculateLength [Number?] size in +bytes+ if it is known
      * @param charset [Charset] the charset to write with
+     * @param repeatable [Boolean] loads the body into memory upon reading
      *
      * @return [Request] the request
      */
-    fun body(openStream: BodySource, calculateLength: BodyLength? = null, charset: Charset = Charsets.UTF_8): Request
+    fun body(openStream: BodySource, calculateLength: BodyLength? = null, charset: Charset = Charsets.UTF_8, repeatable: Boolean = false): Request
 
     /**
      * Sets the body from a generic stream
@@ -404,10 +405,11 @@ interface Request : RequestFactory.RequestConvertible {
      * @param stream [InputStream] a stream to read from
      * @param calculateLength [Number?] size in bytes if it is known
      * @param charset [Charset] the charset to write with
+     * @param repeatable [Boolean] loads the body into memory upon reading
      *
      * @return [Request] the request
      */
-    fun body(stream: InputStream, calculateLength: BodyLength? = null, charset: Charset = Charsets.UTF_8): Request
+    fun body(stream: InputStream, calculateLength: BodyLength? = null, charset: Charset = Charsets.UTF_8, repeatable: Boolean = false): Request
 
     /**
      * Sets the body from a byte array

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/interceptors/RedirectionInterceptor.kt
@@ -51,6 +51,12 @@ fun redirectResponseInterceptor(manager: FuelManager) =
                 .header(newHeaders)
                 .requestProgress(request.executionOptions.requestProgress)
                 .responseProgress(request.executionOptions.responseProgress)
+                .let {
+                    if (newMethod === request.method && !request.body.isEmpty() && !request.body.isConsumed())
+                        it.body(request.body)
+                    else
+                        it
+                }
 
             // Redirect
             next(request, newRequest.response().second)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DefaultBody.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DefaultBody.kt
@@ -61,6 +61,12 @@ data class DefaultBody(
         }
     }
 
+    /**
+     * Makes the body repeatable by e.g. loading its contents into memory
+     * @return [RepeatableBody] the body to be repeated
+     */
+    fun asRepeatable(): RepeatableBody = RepeatableBody(this)
+
     companion object {
         private val EMPTY_STREAM = {
             ByteArrayInputStream(ByteArray(0))
@@ -72,7 +78,7 @@ data class DefaultBody(
             ))
         }
 
-        fun from(openStream: BodySource, calculateLength: BodyLength?, charset: Charset = Charsets.UTF_8): Body {
+        fun from(openStream: BodySource, calculateLength: BodyLength?, charset: Charset = Charsets.UTF_8): DefaultBody {
             return DefaultBody(
                 openStream = openStream,
                 calculateLength = calculateLength,

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DefaultRequest.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/DefaultRequest.kt
@@ -192,11 +192,13 @@ data class DefaultRequest(
      * @param openStream [BodySource] a function that yields a stream
      * @param calculateLength [Number?] size in +bytes+ if it is known
      * @param charset [Charset] the charset to write with
+     * @param repeatable [Boolean] loads the body into memory upon reading
      *
      * @return [Request] the request
      */
-    override fun body(openStream: BodySource, calculateLength: BodyLength?, charset: Charset): Request {
+    override fun body(openStream: BodySource, calculateLength: BodyLength?, charset: Charset, repeatable: Boolean): Request {
         _body = DefaultBody.from(openStream = openStream, calculateLength = calculateLength, charset = charset)
+                           .let { body -> if (repeatable) body.asRepeatable() else body }
         return request
     }
 
@@ -209,11 +211,12 @@ data class DefaultRequest(
      * @param stream [InputStream] a stream to read from
      * @param calculateLength [Number?] size in bytes if it is known
      * @param charset [Charset] the charset to write with
+     * @param repeatable [Boolean] loads the body into memory upon reading
      *
      * @return [Request] the request
      */
-    override fun body(stream: InputStream, calculateLength: BodyLength?, charset: Charset) =
-        body({ stream }, calculateLength, charset)
+    override fun body(stream: InputStream, calculateLength: BodyLength?, charset: Charset, repeatable: Boolean) =
+        body(openStream = { stream }, calculateLength = calculateLength, charset = charset, repeatable = repeatable)
 
     /**
      * Sets the body from a byte array
@@ -223,7 +226,7 @@ data class DefaultRequest(
      * @return [Request] the request
      */
     override fun body(bytes: ByteArray, charset: Charset) =
-        body(ByteArrayInputStream(bytes), { bytes.size.toLong() }, charset)
+        body(stream = ByteArrayInputStream(bytes), calculateLength = { bytes.size.toLong() }, charset = charset, repeatable = true)
 
     /**
      * Sets the body from a string
@@ -233,7 +236,7 @@ data class DefaultRequest(
      * @return [Request] the request
      */
     override fun body(body: String, charset: Charset): Request =
-        body(body.toByteArray(charset), charset)
+        body(bytes = body.toByteArray(charset), charset = charset)
 
     /**
      * Sets the body to the contents of a file.

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/RepeatableBody.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/requests/RepeatableBody.kt
@@ -1,0 +1,72 @@
+package com.github.kittinunf.fuel.core.requests
+
+import com.github.kittinunf.fuel.core.Body
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * A Repeatable Body wraps a body and on the first [writeTo] it keeps the bytes in memory so it can be written again.
+ *
+ * Delegation is not possible because the [body] is re-assigned, and the delegation would point to the initial
+ *   assignment.
+ */
+data class RepeatableBody(
+    var body: Body
+) : Body {
+
+    /**
+     * Writes the body to the [OutputStream].
+     *
+     * @note callers are responses for closing the [OutputStream].
+     * @note implementations may choose to make the [Body] `isConsumed` and can not be written or read from again.
+     * @note implementations are recommended to buffer the output stream if they can't ensure bulk writing.
+     *
+     * @param outputStream [OutputStream] the stream to write to
+     * @return [Long] the number of bytes written
+     */
+    override fun writeTo(outputStream: OutputStream): Long {
+        val repeatableBodyStream = ByteArrayInputStream(toByteArray())
+        return body.writeTo(outputStream)
+                .also { length -> body = DefaultBody.from({ repeatableBodyStream }, { length }) }
+    }
+
+    /**
+     * Returns the body as a [ByteArray].
+     *
+     * @note Because the body needs to be read into memory anyway, implementations may choose to make the [Body]
+     *  readable once more after calling this method, with the original [InputStream] being closed (and release its
+     *  resources). This also means that if an implementation choose to keep it around, `isConsumed` returns false.
+     *
+     * @return the entire body
+     */
+    override fun toByteArray() = body.toByteArray()
+
+    /**
+     * Returns the body as an [InputStream].
+     *
+     * @note callers are responsible for closing the returned stream.
+     * @note implementations may choose to make the [Body] `isConsumed` and can not be written or read from again.
+     *
+     * @return the body as input stream
+     */
+    override fun toStream() = body.toStream()
+
+    /**
+     * Returns the body emptiness.
+     * @return [Boolean] if true, this body is empty
+     */
+    override fun isEmpty() = body.isEmpty()
+
+    /**
+     * Returns if the body is consumed.
+     * @return [Boolean] if true, `writeTo`, `toStream` and `toByteArray` may throw
+     */
+    override fun isConsumed() = body.isConsumed()
+
+    /**
+     * Returns the length of the body in bytes
+     * @return [Long?] the length in bytes, null if it is unknown
+     */
+    override val length = body.length
+}

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/BodyTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/BodyTest.kt
@@ -106,7 +106,7 @@ class BodyTest {
     }
 
     @Test(expected = FuelError::class)
-    fun bodyCanOnlyBeReadOnce() {
+    fun bodyFromCallbackCanOnlyBeReadOnce() {
         val body = DefaultBody.from({ ByteArrayInputStream("body".toByteArray()) }, { 4 })
         body.writeTo(ByteArrayOutputStream())
         body.writeTo(ByteArrayOutputStream())
@@ -125,7 +125,7 @@ class BodyTest {
 
     @Test
     fun requestWithBodyIsPrintableAfterConsumption() {
-        val value = "String Body ${Math.random()}"
+        val value = { ByteArrayInputStream("String Body ${Math.random()}".toByteArray()) }
 
         DefaultRequest(Method.POST, URL("https://test.fuel.com/"))
             .body(value)

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/requests/RepeatableBodyTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/requests/RepeatableBodyTest.kt
@@ -1,0 +1,72 @@
+package com.github.kittinunf.fuel.core.requests
+
+import com.github.kittinunf.fuel.core.Method
+import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.net.URL
+
+class RepeatableBodyTest {
+
+    @Test
+    fun repeatableBodyIsNeverConsumed() {
+        val body = DefaultBody.from({ ByteArrayInputStream("body".toByteArray()) }, { 4 }).asRepeatable()
+        assertThat(body.isConsumed(), equalTo(false))
+        body.writeTo(ByteArrayOutputStream())
+        assertThat(body.isConsumed(), equalTo(false))
+    }
+
+    @Test
+    fun byteArrayBodyIsRepeatable() {
+        val value = ByteArray(32).apply {
+            for (i in 0..(this.size - 1)) {
+                this[i] = ('A'..'z').random().toByte()
+            }
+        }
+
+        DefaultRequest(Method.POST, URL("https://test.fuel.com/"))
+            .body(value)
+            .apply {
+                val output = ByteArrayOutputStream(value.size)
+                assertThat(body.length?.toInt(), equalTo(value.size))
+                assertThat(body.toByteArray(), equalTo(value))
+
+                body.writeTo(output)
+                assertThat(output.toString(), equalTo(String(value)))
+                assertThat(body.isConsumed(), equalTo(false))
+            }
+    }
+
+    @Test
+    fun stringBodyIsRepeatable() {
+        val value = "body"
+        DefaultRequest(Method.POST, URL("https://test.fuel.com/"))
+            .body(value)
+            .apply {
+                val output = ByteArrayOutputStream(value.length)
+                assertThat(body.length?.toInt(), equalTo(value.length))
+                assertThat(body.toByteArray(), equalTo(value.toByteArray()))
+
+                body.writeTo(output)
+                assertThat(output.toString(), equalTo(value))
+                assertThat(body.isConsumed(), equalTo(false))
+            }
+    }
+
+    @Test
+    fun requestWithRepeatableBodyIsPrintableAfterConsumption() {
+        val value = "String Body ${Math.random()}"
+
+        DefaultRequest(Method.POST, URL("https://test.fuel.com/"))
+            .body(value)
+            .apply {
+                val output = ByteArrayOutputStream()
+                body.writeTo(output)
+
+                assertThat(this.toString(), CoreMatchers.containsString(value))
+            }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

This change makes bodies repeatable, which is turned on for in-memory values, and turned off for streams by default.

Repeatable bodies are _not_ consumed upon writing and can therefore be sent again on certain redirections.

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [X] This change requires a documentation update

## How Has This Been Tested?

New tests have been added to confirm this behaviour.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new compiler warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
