### PR TITLE
Migrate to Android API Level 28 and AndroidX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ env:
 android:
   components:
     - tools
-    - build-tools-27.0.3
-    - android-27
-    - extra-android-support
-    - extra-android-m2repository
+    - build-tools-28.0.3
+    - android-28
   licenses:
     - android-sdk-license-.+
 

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -30,6 +30,11 @@ object Android {
     const val version = "3.2.1"
     const val appPlugin = "com.android.application"
     const val libPlugin = "com.android.library"
+
+    object Arch {
+        const val version = "1.1.1"
+        const val testingCore = "android.arch.core:core-testing:$version"
+    }
 }
 
 object AndroidX {
@@ -50,9 +55,9 @@ object AndroidX {
     // Testing dependencies
     object Test {
         const val rulesVersion = "1.1.0"
-        const val runnerVersion = "1.1.0"
-        val rules = "androidx.test:rules:$rulesVersion"
-        val runner = "androidx.test:runner:$runnerVersion"
+        const val junitVersion = "1.0.0"
+        const val rules = "androidx.test:rules:$rulesVersion"
+        const val junit = "androidx.test.ext:junit:$junitVersion"
     }
 }
 
@@ -105,7 +110,7 @@ object RxJava {
 
     object Android {
         const val version = "2.1.0"
-        val dependency = "io.reactivex.rxjava2:rxandroid:$version"
+        const val dependency = "io.reactivex.rxjava2:rxandroid:$version"
     }
 }
 

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -3,7 +3,7 @@ object Fuel {
     const val publishVersion = "1.16.0"
     const val groupId = "com.github.kittinunf.fuel"
 
-    const val compileSdkVersion = 27
+    const val compileSdkVersion = 28
     const val minSdkVersion = 19
 }
 
@@ -27,33 +27,32 @@ object Json {
 }
 
 object Android {
-    const val version = "3.1.3"
+    const val version = "3.2.1"
     const val appPlugin = "com.android.application"
     const val libPlugin = "com.android.library"
+}
 
-    object Support {
-        const val version = "27.1.1"
-        val annotation = "com.android.support:support-annotations:$version"
-        val appCompat = "com.android.support:appcompat-v7:$version"
-    }
+object AndroidX {
+	val annotation = "androidx.annotation:annotation:1.0.1"
+	val appCompat = "androidx.appcompat:appcompat:1.0.2"
 
-    object Arch {
-        const val version = "1.1.1"
-        const val extensions = "android.arch.lifecycle:extensions:$version"
-    }
+	object Arch {
+		const val version = "2.0.0"
+		const val extensions = "androidx.lifecycle:lifecycle-extensions:$version"
+	}
 
-    object Espresso {
-        const val version = "3.0.0"
-        const val core = "com.android.support.test.espresso:espresso-core:$version"
-        const val intents = "com.android.support.test.espresso:espresso-intents:$version"
+	object Espresso {
+        const val version = "3.1.0"
+        const val core = "androidx.test.espresso:espresso-core:$version"
+        const val intents = "androidx.test.espresso:espresso-intents:$version"
     }
 
     // Testing dependencies
     object Test {
-        const val rulesVersion = "1.0.0"
-        const val runnerVersion = "1.0.0"
-        val rules = "com.android.support.test:rules:$rulesVersion"
-        val runner = "com.android.support.test:runner:$runnerVersion"
+        const val rulesVersion = "1.1.0"
+        const val runnerVersion = "1.1.0"
+        val rules = "androidx.test:rules:$rulesVersion"
+        val runner = "androidx.test:runner:$runnerVersion"
     }
 }
 

--- a/fuel-livedata/build.gradle.kts
+++ b/fuel-livedata/build.gradle.kts
@@ -5,4 +5,6 @@ dependencies {
     testImplementation(RoboElectric.dependency)
     testImplementation(JUnit.dependency)
     testImplementation(project(":fuel-test"))
+    testImplementation(Android.Arch.testingCore)
+    testImplementation(AndroidX.Test.junit)
 }

--- a/fuel-livedata/build.gradle.kts
+++ b/fuel-livedata/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     api(project(":fuel"))
     implementation(Kotlin.stdlib)
-    implementation(Android.Arch.extensions)
+    implementation(AndroidX.Arch.extensions)
     testImplementation(RoboElectric.dependency)
     testImplementation(JUnit.dependency)
     testImplementation(project(":fuel-test"))

--- a/fuel-livedata/src/main/kotlin/com/github/kittinunf/fuel/livedata/FuelLiveData.kt
+++ b/fuel-livedata/src/main/kotlin/com/github/kittinunf/fuel/livedata/FuelLiveData.kt
@@ -1,7 +1,7 @@
 package com.github.kittinunf.fuel.livedata
 
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.github.kittinunf.fuel.core.Deserializable
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Request

--- a/fuel-livedata/src/test/kotlin/com/github/kittinunf/fuel/livedata/FuelLiveDataTest.kt
+++ b/fuel-livedata/src/test/kotlin/com/github/kittinunf/fuel/livedata/FuelLiveDataTest.kt
@@ -1,5 +1,7 @@
 package com.github.kittinunf.fuel.livedata
 
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.ResponseDeserializable
 import com.github.kittinunf.fuel.test.MockHttpTestCase
@@ -7,13 +9,20 @@ import com.github.kittinunf.result.Result
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Rule
+import org.junit.runner.RunWith
 import org.junit.Test
 import java.net.HttpURLConnection
 
 /**
  * @see [Testing documentation](http://d.android.com/tools/testing)
  */
+@RunWith(AndroidJUnit4::class)
 class FuelLiveDataTest : MockHttpTestCase() {
+
+    @Rule
+    @JvmField
+    val rule = InstantTaskExecutorRule()
 
     @Test
     fun liveDataTestResponse() {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 dependencies {
     implementation(Kotlin.stdlib)
-    implementation(Android.Support.appCompat)
+    implementation(AndroidX.appCompat)
     implementation(KotlinX.Coroutines.android)
     implementation(RxJava.Android.dependency)
 
@@ -19,11 +19,11 @@ dependencies {
     api(project(":fuel-gson"))
     api(project(":fuel-coroutines"))
 
-    androidTestImplementation(Android.Support.annotation)
-    androidTestImplementation(Android.Test.runner)
-    androidTestImplementation(Android.Test.rules)
-    androidTestImplementation(Android.Espresso.core)
-    androidTestImplementation(Android.Espresso.intents)
+    androidTestImplementation(AndroidX.annotation)
+    androidTestImplementation(AndroidX.Test.runner)
+    androidTestImplementation(AndroidX.Test.rules)
+    androidTestImplementation(AndroidX.Espresso.core)
+    androidTestImplementation(AndroidX.Espresso.intents)
 }
 
 configure<BaseExtension> {
@@ -35,7 +35,7 @@ configure<BaseExtension> {
         targetSdkVersion(Fuel.compileSdkVersion)
         versionCode = 1
         versionName = "1.0"
-        testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     sourceSets {
@@ -53,13 +53,5 @@ configure<BaseExtension> {
     packagingOptions {
         exclude("META-INF/LICENSE.txt")
         exclude("META-INF/NOTICE.txt")
-    }
-}
-
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "android.arch.lifecycle") {
-            useVersion("1.1.1")
-        }
     }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     api(project(":fuel-coroutines"))
 
     androidTestImplementation(AndroidX.annotation)
-    androidTestImplementation(AndroidX.Test.runner)
+    androidTestImplementation(AndroidX.Test.junit)
     androidTestImplementation(AndroidX.Test.rules)
     androidTestImplementation(AndroidX.Espresso.core)
     androidTestImplementation(AndroidX.Espresso.intents)

--- a/sample/src/main/kotlin/com/example/fuel/MainActivity.kt
+++ b/sample/src/main/kotlin/com/example/fuel/MainActivity.kt
@@ -2,8 +2,8 @@ package com.example.fuel
 
 import android.os.Bundle
 import android.os.Handler
-import android.support.v7.app.AppCompatActivity
 import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
 import com.github.kittinunf.fuel.coroutines.awaitStringResponseResult
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.FuelError
@@ -173,7 +173,7 @@ class MainActivity : AppCompatActivity() {
     private fun httpDownload() {
         val n = 100
         Fuel.download("/bytes/${1024 * n}")
-            .destination { _, _ -> File(filesDir, "test.tmp") }
+            .fileDestination { _, _ -> File(filesDir, "test.tmp") }
             .progress { readBytes, totalBytes ->
                 val progress = "$readBytes / $totalBytes"
                 runOnUiThread { mainAuxText.text = progress }
@@ -210,13 +210,13 @@ class MainActivity : AppCompatActivity() {
             .authentication()
             .basic(username, password)
             .also { Log.d(TAG, it.cUrlString()) }
-            .responseString { request, _, result -> update(result) }
+            .responseString { _, _, result -> update(result) }
 
         "/basic-auth/$username/$password".httpGet()
             .authentication()
             .basic(username, password)
             .also { Log.d(TAG, it.cUrlString()) }
-            .responseString { request, _, result -> update(result) }
+            .responseString { _, _, result -> update(result) }
     }
 
     private fun httpRxSupport() {


### PR DESCRIPTION
## Description

Change Android API Level to 28 from 27
Migrate to a brand new Android Support Library is AndroidX

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In case you did not include tests describe why you and how you have verified the
changes, with instructions so we can reproduce. If you have added comprehensive
tests for your changes, you may omit this section.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
