### PR TITLE
Fix body representation in case of `charset` in ContentType

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/BodyRepresentation.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/BodyRepresentation.kt
@@ -1,5 +1,7 @@
 package com.github.kittinunf.fuel.core
 
+import java.nio.charset.Charset
+
 private val TEXT_CONTENT_TYPE = Regex(
     "^(?:text/.*|application/(?:csv|javascript|json|typescript|xml|x-yaml|x-www-form-urlencoded|vnd\\.coffeescript)|.*\\+(?:xml|json))(; charset=.+)*$"
 )
@@ -14,7 +16,13 @@ fun Body.representationOfBytes(contentType: String?): String {
     val actualContentType = if (contentType.isNullOrEmpty()) "(unknown)" else contentType
 
     if (TEXT_CONTENT_TYPE.matches(actualContentType)) {
-        return String(toByteArray())
+        var charset = Charsets.UTF_8
+        val charsetGroup = TEXT_CONTENT_TYPE.find(actualContentType)!!.groupValues[1]
+        if (charsetGroup.isNotEmpty()) {
+            val charsetName = charsetGroup.substringAfter('=').toUpperCase()
+            charset = Charset.forName(charsetName)
+        }
+        return String(toByteArray(), charset)
     }
 
     val lengthLabel = (length ?: -1L).let {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/BodyRepresentation.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/BodyRepresentation.kt
@@ -1,7 +1,7 @@
 package com.github.kittinunf.fuel.core
 
 private val TEXT_CONTENT_TYPE = Regex(
-    "^(?:text/.*|application/(?:csv|javascript|json|typescript|xml|x-yaml|x-www-form-urlencoded|vnd\\.coffeescript)|.*\\+(?:xml|json))$"
+    "^(?:text/.*|application/(?:csv|javascript|json|typescript|xml|x-yaml|x-www-form-urlencoded|vnd\\.coffeescript)|.*\\+(?:xml|json))(; charset=.+)*$"
 )
 
 /**

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/BodyRepresentationTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/BodyRepresentationTest.kt
@@ -152,6 +152,21 @@ class BodyRepresentationTest : MockHttpTestCase() {
     }
 
     @Test
+    fun textRepresentationOfJsonWithUtf8Charset() {
+        val contentTypes = listOf("application/json; charset=utf-8")
+        val content = "{ \"foo\": 42 }"
+
+        contentTypes.forEach { contentType ->
+            assertThat(
+                    DefaultBody
+                            .from({ ByteArrayInputStream(content.toByteArray()) }, { content.length.toLong() })
+                            .asString(contentType),
+                    equalTo(content)
+            )
+        }
+    }
+
+    @Test
     fun textRepresentationOfCsv() {
         val contentTypes = listOf("text/csv")
         val content = "function test()"
@@ -162,6 +177,21 @@ class BodyRepresentationTest : MockHttpTestCase() {
                     .from({ ByteArrayInputStream(content.toByteArray()) }, { content.length.toLong() })
                     .asString(contentType),
                 equalTo(content)
+            )
+        }
+    }
+
+    @Test
+    fun textRepresentationOfCsvWithUtf16beCharset() {
+        val contentTypes = listOf("application/csv; charset=utf-16be")
+        val content = String("hello,world!".toByteArray(Charsets.UTF_16BE))
+
+        contentTypes.forEach { contentType ->
+            assertThat(
+                    DefaultBody
+                            .from({ ByteArrayInputStream(content.toByteArray()) }, { content.length.toLong() })
+                            .asString(contentType),
+                    equalTo("hello,world!")
             )
         }
     }


### PR DESCRIPTION
## Description

Very often `Content-Type` header in responses contains `charset` and it fails body representation (e.g. when call `response.toString()`): instead of body's text representation we see `(XX bytes of application/json; charset=UTF-8)` for example. This fix adds to `TEXT_CONTENT_TYPE` regex support for [rich set of character sets](http://www.iana.org/assignments/character-sets/character-sets.xhtml).

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added 2 tests:
- for `application/json; charset=utf-8`
- for `application/csv; charset=utf-16be`

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
