### PR TITLE
[Feature] :sparkles: Allow user to supply Moshi custom adapter

### DIFF
--- a/fuel-moshi/src/main/kotlin/com/github/kittinunf/fuel/moshi/FuelMoshi.kt
+++ b/fuel-moshi/src/main/kotlin/com/github/kittinunf/fuel/moshi/FuelMoshi.kt
@@ -1,14 +1,18 @@
 package com.github.kittinunf.fuel.moshi
 
 import com.github.kittinunf.fuel.core.FuelError
-import com.github.kittinunf.fuel.core.ResponseHandler
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.ResponseDeserializable
+import com.github.kittinunf.fuel.core.ResponseHandler
 import com.github.kittinunf.fuel.core.response
 import com.github.kittinunf.result.Result
-import com.squareup.moshi.Moshi
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import okio.Okio
+import java.io.InputStream
+
+val defaultMoshi = Moshi.Builder()
 
 inline fun <reified T : Any> Request.responseObject(noinline handler: (Request, Response, Result<T, FuelError>) -> Unit) =
         response(moshiDeserializerOf(T::class.java), handler)
@@ -18,13 +22,14 @@ inline fun <reified T : Any> Request.responseObject(handler: ResponseHandler<T>)
 inline fun <reified T : Any> Request.responseObject() = response(moshiDeserializerOf(T::class.java))
 
 fun <T : Any> moshiDeserializerOf(clazz: Class<T>) = object : ResponseDeserializable<T> {
-    override fun deserialize(content: String): T? = Moshi.Builder()
-                .build()
-                .adapter(clazz)
-                .fromJson(content)
+    override fun deserialize(content: String): T? = defaultMoshi
+            .build()
+            .adapter(clazz)
+            .fromJson(content)
 }
 
 inline fun <reified T : Any> moshiDeserializerOf(adapter: JsonAdapter<T>) = object : ResponseDeserializable<T> {
-    override fun deserialize(content: String): T? =
-            adapter.fromJson(content)
+    override fun deserialize(content: String): T? = adapter.fromJson(content)
+
+    override fun deserialize(inputStream: InputStream): T? = adapter.fromJson(Okio.buffer(Okio.source(inputStream)))
 }

--- a/fuel-moshi/src/test/kotlin/com/github/kittinunf/fuel/FuelMoshiTest.kt
+++ b/fuel-moshi/src/test/kotlin/com/github/kittinunf/fuel/FuelMoshiTest.kt
@@ -33,8 +33,8 @@ class FuelMoshiTest : MockHttpTestCase() {
     @Test
     fun moshiTestResponseObject() {
         mock.chain(
-                request = mock.request().withPath("/user-agent"),
-                response = mock.reflect()
+            request = mock.request().withPath("/user-agent"),
+            response = mock.reflect()
         )
 
         Fuel.get(mock.path("user-agent"))
@@ -47,8 +47,8 @@ class FuelMoshiTest : MockHttpTestCase() {
     @Test
     fun moshiTestResponseObjectError() {
         mock.chain(
-                request = mock.request().withPath("/user-agent"),
-                response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
+            request = mock.request().withPath("/user-agent"),
+            response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
         )
 
         Fuel.get(mock.path("user-agent")).responseObject(moshiDeserializerOf(HttpBinUserAgentModel::class.java)) { _, _, result ->
@@ -60,74 +60,70 @@ class FuelMoshiTest : MockHttpTestCase() {
     @Test
     fun moshiTestResponseDeserializerObject() {
         mock.chain(
-                request = mock.request().withPath("/user-agent"),
-                response = mock.reflect()
+            request = mock.request().withPath("/user-agent"),
+            response = mock.reflect()
         )
 
-        Fuel.get(mock.path("user-agent"))
-                .responseObject<HttpBinUserAgentModel> { _, _, result ->
-                    assertThat(result.component1(), notNullValue())
-                    assertThat(result.component2(), notNullValue())
-                }
+        Fuel.get(mock.path("user-agent")).responseObject<HttpBinUserAgentModel> { _, _, result ->
+            assertThat(result.component1(), notNullValue())
+            assertThat(result.component2(), notNullValue())
+        }
     }
 
     @Test
     fun moshiTestResponseDeserializerObjectError() {
         mock.chain(
-                request = mock.request().withPath("/user-agent"),
-                response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
+            request = mock.request().withPath("/user-agent"),
+            response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
         )
 
-        Fuel.get(mock.path("user-agent"))
-                .responseObject<HttpBinUserAgentModel> { _, _, result ->
-                    assertThat(result.component1(), notNullValue())
-                    assertThat(result.component2(), instanceOf(Result.Failure::class.java))
-                }
+        Fuel.get(mock.path("user-agent")).responseObject<HttpBinUserAgentModel> { _, _, result ->
+            assertThat(result.component1(), notNullValue())
+            assertThat(result.component2(), instanceOf(Result.Failure::class.java))
+        }
     }
 
     @Test
     fun moshiTestResponseHandlerObject() {
         mock.chain(
-                request = mock.request().withPath("/user-agent"),
-                response = mock.reflect()
+            request = mock.request().withPath("/user-agent"),
+            response = mock.reflect()
         )
 
-        Fuel.get(mock.path("user-agent"))
-                .responseObject(object : ResponseHandler<HttpBinUserAgentModel> {
-                    override fun success(request: Request, response: Response, value: HttpBinUserAgentModel) {
-                        assertThat(value, notNullValue())
-                    }
+        Fuel.get(mock.path("user-agent")).responseObject(object : ResponseHandler<HttpBinUserAgentModel> {
+            override fun success(request: Request, response: Response, value: HttpBinUserAgentModel) {
+                assertThat(value, notNullValue())
+            }
 
-                    override fun failure(request: Request, response: Response, error: FuelError) {
-                        assertThat(error, notNullValue())
-                    }
-                })
+            override fun failure(request: Request, response: Response, error: FuelError) {
+                assertThat(error, notNullValue())
+            }
+        })
     }
 
     @Test
     fun moshiTestResponseHandlerObjectError() {
         mock.chain(
-                request = mock.request().withPath("/user-agent"),
-                response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
+            request = mock.request().withPath("/user-agent"),
+            response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
         )
 
-        Fuel.get(mock.path("user-agent"))
-                .responseObject(object : ResponseHandler<HttpBinUserAgentModel> {
-                    override fun success(request: Request, response: Response, value: HttpBinUserAgentModel) {
-                        assertThat(value, notNullValue())
-                    }
+        Fuel.get(mock.path("user-agent")).responseObject(object : ResponseHandler<HttpBinUserAgentModel> {
+            override fun success(request: Request, response: Response, value: HttpBinUserAgentModel) {
+                assertThat(value, notNullValue())
+            }
 
-                    override fun failure(request: Request, response: Response, error: FuelError) {
-                        assertThat(error, instanceOf(Result.Failure::class.java))
-                    }
-                })
+            override fun failure(request: Request, response: Response, error: FuelError) {
+                assertThat(error, instanceOf(Result.Failure::class.java))
+            }
+        })
     }
 
     @Test
     fun moshiTestResponseSyncObject() {
         mock.chain(
-                request = mock.request().withPath("/user-agent"),
-                response = mock.reflect()
+            request = mock.request().withPath("/user-agent"),
+            response = mock.reflect()
         )
 
         val triple = Fuel.get(mock.path("user-agent")).responseObject<HttpBinUserAgentModel>()
@@ -138,8 +134,8 @@ class FuelMoshiTest : MockHttpTestCase() {
     @Test
     fun moshiTestResponseSyncObjectError() {
         mock.chain(
-                request = mock.request().withPath("/user-agent"),
-                response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
+            request = mock.request().withPath("/user-agent"),
+            response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
         )
 
         val triple = Fuel.get(mock.path("user-agent")).responseObject<HttpBinUserAgentModel>()
@@ -149,18 +145,17 @@ class FuelMoshiTest : MockHttpTestCase() {
     @Test
     fun moshiTestResponseObjectErrorWithGivenAdapter() {
         mock.chain(
-                request = mock.request().withPath("/user-agent"),
-                response = mock.reflect()
+            request = mock.request().withPath("/user-agent"),
+            response = mock.reflect()
         )
 
         val moshi = Moshi.Builder().build()
         val adapter = moshi.adapter(HttpBinUserAgentModel::class.java)
 
-        Fuel.get(mock.path("user-agent"))
-                .responseObject(moshiDeserializerOf(adapter)) { _, _, result ->
-                    assertThat(result.component1(), notNullValue())
-                    assertThat(result.component2(), notNullValue())
-                }
+        Fuel.get(mock.path("user-agent")).responseObject(moshiDeserializerOf(adapter)) { _, _, result ->
+            assertThat(result.component1(), notNullValue())
+            assertThat(result.component2(), notNullValue())
+        }
     }
 
     data class IssueInfo(val id: Int, val title: String, val number: Int)
@@ -171,11 +166,11 @@ class FuelMoshiTest : MockHttpTestCase() {
     @Test
     fun moshiTestProcessingGenericList() {
         mock.chain(
-                request = mock.request().withPath("/issues"),
-                response = mock.response().withBody("[ " +
-                        "{ \"id\": 1, \"title\": \"issue 1\", \"number\": null }, " +
-                        "{ \"id\": 2, \"title\": \"issue 2\", \"number\": 32 }, " +
-                        " ]").withStatusCode(HttpURLConnection.HTTP_OK)
+            request = mock.request().withPath("/issues"),
+            response = mock.response().withBody("[ " +
+                    "{ \"id\": 1, \"title\": \"issue 1\", \"number\": null }, " +
+                    "{ \"id\": 2, \"title\": \"issue 2\", \"number\": 32 }, " +
+                    " ]").withStatusCode(HttpURLConnection.HTTP_OK)
         )
 
         Fuel.get(mock.path("issues")).responseObject<List<IssueInfo>> { _, _, result ->
@@ -215,12 +210,18 @@ class FuelMoshiTest : MockHttpTestCase() {
         defaultMoshi.add(TypeToken.of(Stage::class.java).type, StageMoshiAdapter())
 
         mock.apply {
-            chain(request = mock.request().withPath("/stage1"),
-                    response = mock.response().withBody(""" { "stage" : "na" } """.trimIndent()))
-            chain(request = mock.request().withPath("/stage2"),
-                    response = mock.response().withBody(""" { "stage" : "in_progress" } """.trimIndent()))
-            chain(request = mock.request().withPath("/stage3"),
-                    response = mock.response().withBody(""" { "stage" : "finished" } """.trimIndent()))
+            chain(
+                request = mock.request().withPath("/stage1"),
+                response = mock.response().withBody(""" { "stage" : "na" } """.trimIndent())
+            )
+            chain(
+                request = mock.request().withPath("/stage2"),
+                response = mock.response().withBody(""" { "stage" : "in_progress" } """.trimIndent())
+            )
+            chain(
+                request = mock.request().withPath("/stage3"),
+                response = mock.response().withBody(""" { "stage" : "finished" } """.trimIndent())
+            )
         }
 
         val (req, res, res1) = Fuel.get(mock.path("stage1")).responseObject<StageDTO>()
@@ -246,8 +247,10 @@ class FuelMoshiTest : MockHttpTestCase() {
         defaultMoshi.add(TypeToken.of(Stage::class.java).type, StageMoshiAdapter())
 
         mock.apply {
-            chain(request = mock.request().withPath("/stage-error"),
-                    response = mock.response().withBody(""" { "stage" : "abcdef" } """.trimIndent()))
+            chain(
+                request = mock.request().withPath("/stage-error"),
+                response = mock.response().withBody(""" { "stage" : "abcdef" } """.trimIndent())
+            )
         }
 
         val (req, res, res1) = Fuel.get(mock.path("stage-error")).responseObject<StageDTO>()

--- a/fuel-moshi/src/test/kotlin/com/github/kittinunf/fuel/FuelMoshiTest.kt
+++ b/fuel-moshi/src/test/kotlin/com/github/kittinunf/fuel/FuelMoshiTest.kt
@@ -4,12 +4,22 @@ import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.ResponseHandler
+import com.github.kittinunf.fuel.moshi.defaultMoshi
 import com.github.kittinunf.fuel.moshi.moshiDeserializerOf
 import com.github.kittinunf.fuel.moshi.responseObject
 import com.github.kittinunf.fuel.test.MockHttpTestCase
 import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.Result.Failure
+import com.github.kittinunf.result.Result.Success
+import com.google.common.reflect.TypeToken
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.CoreMatchers.isA
 import org.hamcrest.CoreMatchers.notNullValue
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertThat
@@ -23,42 +33,42 @@ class FuelMoshiTest : MockHttpTestCase() {
     @Test
     fun moshiTestResponseObject() {
         mock.chain(
-            request = mock.request().withPath("/user-agent"),
-            response = mock.reflect()
+                request = mock.request().withPath("/user-agent"),
+                response = mock.reflect()
         )
 
         Fuel.get(mock.path("user-agent"))
-            .responseObject(moshiDeserializerOf(HttpBinUserAgentModel::class.java)) { _, _, result ->
-                assertThat(result.component1(), notNullValue())
-                assertThat(result.component2(), notNullValue())
-            }
+                .responseObject(moshiDeserializerOf(HttpBinUserAgentModel::class.java)) { _, _, result ->
+                    assertThat(result.component1(), notNullValue())
+                    assertThat(result.component2(), notNullValue())
+                }
     }
 
     @Test
     fun moshiTestResponseObjectError() {
         mock.chain(
-            request = mock.request().withPath("/user-agent"),
-            response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
+                request = mock.request().withPath("/user-agent"),
+                response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
         )
 
         Fuel.get(mock.path("user-agent")).responseObject(moshiDeserializerOf(HttpBinUserAgentModel::class.java)) { _, _, result ->
-                assertThat(result.component1(), notNullValue())
-                assertThat(result.component2(), instanceOf(Result.Failure::class.java))
-            }
+            assertThat(result.component1(), notNullValue())
+            assertThat(result.component2(), instanceOf(Result.Failure::class.java))
+        }
     }
 
     @Test
     fun moshiTestResponseDeserializerObject() {
         mock.chain(
-            request = mock.request().withPath("/user-agent"),
-            response = mock.reflect()
+                request = mock.request().withPath("/user-agent"),
+                response = mock.reflect()
         )
 
         Fuel.get(mock.path("user-agent"))
-            .responseObject<HttpBinUserAgentModel> { _, _, result ->
-                assertThat(result.component1(), notNullValue())
-                assertThat(result.component2(), notNullValue())
-            }
+                .responseObject<HttpBinUserAgentModel> { _, _, result ->
+                    assertThat(result.component1(), notNullValue())
+                    assertThat(result.component2(), notNullValue())
+                }
     }
 
     @Test
@@ -69,10 +79,10 @@ class FuelMoshiTest : MockHttpTestCase() {
         )
 
         Fuel.get(mock.path("user-agent"))
-            .responseObject<HttpBinUserAgentModel> { _, _, result ->
-                assertThat(result.component1(), notNullValue())
-                assertThat(result.component2(), instanceOf(Result.Failure::class.java))
-            }
+                .responseObject<HttpBinUserAgentModel> { _, _, result ->
+                    assertThat(result.component1(), notNullValue())
+                    assertThat(result.component2(), instanceOf(Result.Failure::class.java))
+                }
     }
 
     @Test
@@ -83,15 +93,15 @@ class FuelMoshiTest : MockHttpTestCase() {
         )
 
         Fuel.get(mock.path("user-agent"))
-            .responseObject(object : ResponseHandler<HttpBinUserAgentModel> {
-                override fun success(request: Request, response: Response, value: HttpBinUserAgentModel) {
-                    assertThat(value, notNullValue())
-                }
+                .responseObject(object : ResponseHandler<HttpBinUserAgentModel> {
+                    override fun success(request: Request, response: Response, value: HttpBinUserAgentModel) {
+                        assertThat(value, notNullValue())
+                    }
 
-                override fun failure(request: Request, response: Response, error: FuelError) {
-                    assertThat(error, notNullValue())
-                }
-            })
+                    override fun failure(request: Request, response: Response, error: FuelError) {
+                        assertThat(error, notNullValue())
+                    }
+                })
     }
 
     @Test
@@ -102,22 +112,22 @@ class FuelMoshiTest : MockHttpTestCase() {
         )
 
         Fuel.get(mock.path("user-agent"))
-            .responseObject(object : ResponseHandler<HttpBinUserAgentModel> {
-                override fun success(request: Request, response: Response, value: HttpBinUserAgentModel) {
-                    assertThat(value, notNullValue())
-                }
+                .responseObject(object : ResponseHandler<HttpBinUserAgentModel> {
+                    override fun success(request: Request, response: Response, value: HttpBinUserAgentModel) {
+                        assertThat(value, notNullValue())
+                    }
 
-                override fun failure(request: Request, response: Response, error: FuelError) {
-                    assertThat(error, instanceOf(Result.Failure::class.java))
-                }
-            })
+                    override fun failure(request: Request, response: Response, error: FuelError) {
+                        assertThat(error, instanceOf(Result.Failure::class.java))
+                    }
+                })
     }
 
     @Test
     fun moshiTestResponseSyncObject() {
         mock.chain(
-            request = mock.request().withPath("/user-agent"),
-            response = mock.reflect()
+                request = mock.request().withPath("/user-agent"),
+                response = mock.reflect()
         )
 
         val triple = Fuel.get(mock.path("user-agent")).responseObject<HttpBinUserAgentModel>()
@@ -128,8 +138,8 @@ class FuelMoshiTest : MockHttpTestCase() {
     @Test
     fun moshiTestResponseSyncObjectError() {
         mock.chain(
-            request = mock.request().withPath("/user-agent"),
-            response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
+                request = mock.request().withPath("/user-agent"),
+                response = mock.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
         )
 
         val triple = Fuel.get(mock.path("user-agent")).responseObject<HttpBinUserAgentModel>()
@@ -139,18 +149,18 @@ class FuelMoshiTest : MockHttpTestCase() {
     @Test
     fun moshiTestResponseObjectErrorWithGivenAdapter() {
         mock.chain(
-            request = mock.request().withPath("/user-agent"),
-            response = mock.reflect()
+                request = mock.request().withPath("/user-agent"),
+                response = mock.reflect()
         )
 
         val moshi = Moshi.Builder().build()
         val adapter = moshi.adapter(HttpBinUserAgentModel::class.java)
 
         Fuel.get(mock.path("user-agent"))
-            .responseObject(moshiDeserializerOf(adapter)) { _, _, result ->
-                assertThat(result.component1(), notNullValue())
-                assertThat(result.component2(), notNullValue())
-            }
+                .responseObject(moshiDeserializerOf(adapter)) { _, _, result ->
+                    assertThat(result.component1(), notNullValue())
+                    assertThat(result.component2(), notNullValue())
+                }
     }
 
     data class IssueInfo(val id: Int, val title: String, val number: Int)
@@ -159,13 +169,13 @@ class FuelMoshiTest : MockHttpTestCase() {
      * Test for https://github.com/kittinunf/Fuel/issues/233
      */
     @Test
-    fun testProcessingGenericList() {
+    fun moshiTestProcessingGenericList() {
         mock.chain(
-            request = mock.request().withPath("/issues"),
-            response = mock.response().withBody("[ " +
-                    "{ \"id\": 1, \"title\": \"issue 1\", \"number\": null }, " +
-                    "{ \"id\": 2, \"title\": \"issue 2\", \"number\": 32 }, " +
-                    " ]").withStatusCode(HttpURLConnection.HTTP_OK)
+                request = mock.request().withPath("/issues"),
+                response = mock.response().withBody("[ " +
+                        "{ \"id\": 1, \"title\": \"issue 1\", \"number\": null }, " +
+                        "{ \"id\": 2, \"title\": \"issue 2\", \"number\": 32 }, " +
+                        " ]").withStatusCode(HttpURLConnection.HTTP_OK)
         )
 
         Fuel.get(mock.path("issues")).responseObject<List<IssueInfo>> { _, _, result ->
@@ -173,5 +183,78 @@ class FuelMoshiTest : MockHttpTestCase() {
             assertNotEquals(issues.size, 0)
             assertThat(issues[0], instanceOf(IssueInfo::class.java))
         }
+    }
+
+    enum class Stage {
+        @Json(name = "na")
+        UNKNOWN,
+        IN_PROGRESS,
+        FINISHED
+    }
+
+    data class StageDTO(val stage: Stage)
+
+    class StageMoshiAdapter : JsonAdapter<Stage>() {
+        override fun fromJson(reader: JsonReader): Stage? {
+            val value = reader.nextString()
+
+            return when (value) {
+                "na" -> Stage.UNKNOWN
+                "in_progress" -> Stage.IN_PROGRESS
+                "finished" -> Stage.FINISHED
+                else -> error("No supported value")
+            }
+        }
+
+        override fun toJson(writer: JsonWriter, value: Stage?) {
+        }
+    }
+
+    @Test
+    fun moshiTestCustomAdapterSuccess() {
+        defaultMoshi.add(TypeToken.of(Stage::class.java).type, StageMoshiAdapter())
+
+        mock.apply {
+            chain(request = mock.request().withPath("/stage1"),
+                    response = mock.response().withBody(""" { "stage" : "na" } """.trimIndent()))
+            chain(request = mock.request().withPath("/stage2"),
+                    response = mock.response().withBody(""" { "stage" : "in_progress" } """.trimIndent()))
+            chain(request = mock.request().withPath("/stage3"),
+                    response = mock.response().withBody(""" { "stage" : "finished" } """.trimIndent()))
+        }
+
+        val (req, res, res1) = Fuel.get(mock.path("stage1")).responseObject<StageDTO>()
+
+        assertThat(req, notNullValue())
+        assertThat(res, notNullValue())
+        assertThat(res1 as Success, isA(Result.Success::class.java))
+        assertThat(res1.value.stage, equalTo(Stage.UNKNOWN))
+
+        val (_, _, res2) = Fuel.get(mock.path("stage2")).responseObject<StageDTO>()
+
+        assertThat(res2 as Success, isA(Result.Success::class.java))
+        assertThat(res2.value.stage, equalTo(Stage.IN_PROGRESS))
+
+        val (_, _, res3) = Fuel.get(mock.path("stage3")).responseObject<StageDTO>()
+
+        assertThat(res3 as Success, isA(Result.Success::class.java))
+        assertThat(res3.value.stage, equalTo(Stage.FINISHED))
+    }
+
+    @Test
+    fun moshiTestCustomAdapterFailure() {
+        defaultMoshi.add(TypeToken.of(Stage::class.java).type, StageMoshiAdapter())
+
+        mock.apply {
+            chain(request = mock.request().withPath("/stage-error"),
+                    response = mock.response().withBody(""" { "stage" : "abcdef" } """.trimIndent()))
+        }
+
+        val (req, res, res1) = Fuel.get(mock.path("stage-error")).responseObject<StageDTO>()
+
+        assertThat(req, notNullValue())
+        assertThat(res, notNullValue())
+        assertThat(res1 as Failure, isA(Result.Failure::class.java))
+        assertThat(res1.error.exception as IllegalStateException, isA(IllegalStateException::class.java))
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

This PR allows users to supply with customization over the Moshi builder. This could be done via top-level moshi instance named `defaultMoshi`.

This supersedes #614 so it closes #614 and closes #609

<!-- Include a summary of the change and which [issue](https://github.com/kittinunf/Fuel/issues)
this fixes. Also, include relevant motivation and context. List any dependencies
that are required for this change and why they are necessary. -->

<!-- Fixes #0
Fixes #0 -->

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In case you did not include tests describe why you and how you have verified the
changes, with instructions so we can reproduce. If you have added comprehensive
tests for your changes, you may omit this section.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
