### PR TITLE
:sparkles: Improve FuelError and BubbleFuelError

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
@@ -7,7 +7,7 @@ private typealias StackTrace = Array<out StackTraceElement>
 /**
  * Indicates a call to [FuelError.wrap] passing in a [FuelError]
  */
-private class BubbleFuelError(inner: FuelError) : FuelError(inner, inner.response)
+private class BubbleFuelError(val inner: FuelError) : FuelError(inner, inner.response)
 
 /**
  * Error wrapper for all caught [Throwable] in fuel
@@ -81,7 +81,7 @@ open class FuelError internal constructor(
 
     companion object {
         fun wrap(it: Throwable, response: Response = Response.error()): FuelError = when (it) {
-            is BubbleFuelError -> BubbleFuelError(FuelError(it.exception, it.response))
+            is BubbleFuelError -> BubbleFuelError(it.inner) // we use underlying FuelError to prevent multiple wrap of BubbleFuelError
             is FuelError -> BubbleFuelError(it)
             else -> FuelError(it, response = response)
         }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
@@ -7,7 +7,7 @@ private typealias StackTrace = Array<out StackTraceElement>
 /**
  * Indicates a call to [FuelError.wrap] passing in a [FuelError]
  */
-private class BubbleFuelError(inner: FuelError) : FuelError(inner, inner.response)
+private class BubbleFuelError(val inner: FuelError) : FuelError(inner, inner.response)
 
 /**
  * Error wrapper for all caught [Throwable] in fuel
@@ -37,7 +37,7 @@ open class FuelError internal constructor(
     /**
      * Returns a string representation of the error with the complete stack
      */
-    override fun toString(): String = "${this::class.java.canonicalName}: $message\r\n".plus(buildString {
+    override fun toString(): String = "${exception.message ?: exception::class.java.canonicalName}\r\n".plus(buildString {
         stackTrace.forEach { stack -> appendln("\t$stack") }
 
         cause?.also {
@@ -81,6 +81,7 @@ open class FuelError internal constructor(
 
     companion object {
         fun wrap(it: Throwable, response: Response = Response.error()): FuelError = when (it) {
+            is BubbleFuelError -> BubbleFuelError(it.inner)
             is FuelError -> BubbleFuelError(it)
             else -> FuelError(it, response = response)
         }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
@@ -7,7 +7,7 @@ private typealias StackTrace = Array<out StackTraceElement>
 /**
  * Indicates a call to [FuelError.wrap] passing in a [FuelError]
  */
-private class BubbleFuelError(val inner: FuelError) : FuelError(inner, inner.response)
+private class BubbleFuelError(inner: FuelError) : FuelError(inner, inner.response)
 
 /**
  * Error wrapper for all caught [Throwable] in fuel
@@ -81,7 +81,7 @@ open class FuelError internal constructor(
 
     companion object {
         fun wrap(it: Throwable, response: Response = Response.error()): FuelError = when (it) {
-            is BubbleFuelError -> BubbleFuelError(it.inner) // we use underlying FuelError to prevent multiple wrap of BubbleFuelError
+            is BubbleFuelError -> BubbleFuelError(FuelError(it.exception, it.response))
             is FuelError -> BubbleFuelError(it)
             else -> FuelError(it, response = response)
         }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/FuelError.kt
@@ -81,7 +81,7 @@ open class FuelError internal constructor(
 
     companion object {
         fun wrap(it: Throwable, response: Response = Response.error()): FuelError = when (it) {
-            is BubbleFuelError -> BubbleFuelError(it.inner)
+            is BubbleFuelError -> BubbleFuelError(it.inner) // we use underlying FuelError to prevent multiple wrap of BubbleFuelError
             is FuelError -> BubbleFuelError(it)
             else -> FuelError(it, response = response)
         }


### PR DESCRIPTION
## Description

<!-- Include a summary of the change and which [issue](https://github.com/kittinunf/Fuel/issues)
this fixes. Also, include relevant motivation and context. List any dependencies
that are required for this change and why they are necessary. -->

<!-- Fixes #0
Fixes #0 -->

This PR improves the discoverability for underlying Exception on `FuelError` and `BubbleFuelError`. This is to make sure that the real Exception that causes the error is easier to trace and more friendly for our user to work with.

There are 2 things this PR introduces.

- Improve the `wrap` to make sure that we don't double wrap our `BubbleFuelError` with yet another `BubbleFuelError`.

- Slightly modify the `toString()` function so that it shows the underlying cause right off the bat. Our user probably doesn't have to know (or care) about both `FuelError` and `BubbleFuelError` so we don't need the javaClassName for them.

This should potentially help combat with obscure #606 and it makes a bit clearer on what `Exception` caused the `FuelError` 

### Result

This is the example of the upgraded `toString()` output with the same error reported in #606.

This snippet:

```kotlin
val (_, _, result) = "https://httpbin.org/get".httpGet().responseString()

println(result)
```

This is console result:

```
I/System.out: [Failure: android.os.NetworkOnMainThreadException
I/System.out: 	com.github.kittinunf.fuel.core.FuelError$Companion.wrap(FuelError.kt:84)
I/System.out: 	com.github.kittinunf.fuel.core.DeserializableKt.response(Deserializable.kt:168)
I/System.out: 	com.github.kittinunf.fuel.core.requests.DefaultRequest.responseString(DefaultRequest.kt:475)
I/System.out: 	com.example.fuel.MainActivity$onCreate$3.onClick(MainActivity.kt:65)
I/System.out: 	android.view.View.performClick(View.java:6597)
I/System.out: 	android.view.View.performClickInternal(View.java:6574)
I/System.out: 	android.view.View.access$3100(View.java:778)
I/System.out: 	android.view.View$PerformClick.run(View.java:25885)
I/System.out: 	android.os.Handler.handleCallback(Handler.java:873)
I/System.out: 	android.os.Handler.dispatchMessage(Handler.java:99)
I/System.out: 	android.os.Looper.loop(Looper.java:193)
I/System.out: 	android.app.ActivityThread.main(ActivityThread.java:6669)
I/System.out: 	java.lang.reflect.Method.invoke(Native Method)
I/System.out: 	com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
I/System.out: 	com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
I/System.out: Caused by: android.os.NetworkOnMainThreadException
I/System.out: 	com.github.kittinunf.fuel.core.FuelError$Companion.wrap(FuelError.kt:86)
I/System.out: 	com.github.kittinunf.fuel.toolbox.HttpClient.executeRequest(HttpClient.kt:40)
I/System.out: Caused by: android.os.NetworkOnMainThreadException
I/System.out: 	android.os.StrictMode$AndroidBlockGuardPolicy.onNetwork(StrictMode.java:1513)
I/System.out: 	java.net.Inet6AddressImpl.lookupHostByName(Inet6AddressImpl.java:117)
I/System.out: 	java.net.Inet6AddressImpl.lookupAllHostAddr(Inet6AddressImpl.java:105)
I/System.out: 	java.net.InetAddress.getAllByName(InetAddress.java:1154)
I/System.out: 	com.android.okhttp.Dns$1.lookup(Dns.java:39)
I/System.out: 	com.android.okhttp.internal.http.RouteSelector.resetNextInetSocketAddress(RouteSelector.java:175)
I/System.out: 	com.android.okhttp.internal.http.RouteSelector.nextProxy(RouteSelector.java:141)
I/System.out: 	com.android.okhttp.internal.http.RouteSelector.next(RouteSelector.java:83)
I/System.out: 	com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:174)
I/System.out: 	com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
I/System.out: 	com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
I/System.out: 	com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
I/System.out: 	com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
I/System.out: 	com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
I/System.out: 	com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:407)
I/System.out: 	com.android.okhttp.internal.huc.HttpURLConnectionImpl.getHeaders(HttpURLConnectionImpl.java:163)
I/System.out: 	com.android.okhttp.internal.huc.HttpURLConnectionImpl.getHeaderFields(HttpURLConnectionImpl.java:223)
I/System.out: 	com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getHeaderFields(DelegatingHttpsURLConnection.java:178)
I/System.out: 	com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getHeaderFields(HttpsURLConnectionImpl.java:26)
I/System.out: 	com.github.kittinunf.fuel.toolbox.HttpClient.retrieveResponse(HttpClient.kt:131)
I/System.out: 	com.github.kittinunf.fuel.toolbox.HttpClient.doRequest(HttpClient.kt:75)
I/System.out: 	com.github.kittinunf.fuel.toolbox.HttpClient.executeRequest(HttpClient.kt:38)
I/System.out: 	com.github.kittinunf.fuel.core.requests.RequestTask.executeRequest(RequestTask.kt:23)
I/System.out: 	com.github.kittinunf.fuel.core.requests.RequestTask.call(RequestTask.kt:44)
I/System.out: 	com.github.kittinunf.fuel.core.requests.RequestTask.call(RequestTask.kt:14)
I/System.out: 	com.github.kittinunf.fuel.core.DeserializableKt.response(Deserializable.kt:166)
I/System.out: 	com.github.kittinunf.fuel.core.requests.DefaultRequest.responseString(DefaultRequest.kt:475)
I/System.out: 	com.example.fuel.MainActivity$onCreate$3.onClick(MainActivity.kt:65)
I/System.out: 	android.view.View.performClick(View.java:6597)
I/System.out: 	android.view.View.performClickInternal(View.java:6574)
I/System.out: 	android.view.View.access$3100(View.java:778)
I/System.out: 	android.view.View$PerformClick.run(View.java:25885)
I/System.out: 	android.os.Handler.handleCallback(Handler.java:873)
I/System.out: 	android.os.Handler.dispatchMessage(Handler.java:99)
I/System.out: 	android.os.Looper.loop(Looper.java:193)
I/System.out: 	android.app.ActivityThread.main(ActivityThread.java:6669)
I/System.out: 	java.lang.reflect.Method.invoke(Native Method)
I/System.out: 	com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
I/System.out: 	com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
I/System.out: ]
```

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In case you did not include tests describe why you and how you have verified the
changes, with instructions so we can reproduce. If you have added comprehensive
tests for your changes, you may omit this section.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
