### PR TITLE
Fix coroutines readme typo

### DIFF
--- a/fuel-coroutines/README.md
+++ b/fuel-coroutines/README.md
@@ -3,7 +3,7 @@ The coroutines extension package for [`Fuel`](../README.md).
 
 ## Installation
 
-You can [download](https://bintray.com/kittinunf/maven/Fuel-Android/_latestVersion) and install `fuel-coroutines` with `Maven` and `Gradle`. The android package has the following dependencies:
+You can [download](https://bintray.com/kittinunf/maven/Fuel-Android/_latestVersion) and install `fuel-coroutines` with `Maven` and `Gradle`. The coroutines package has the following dependencies:
 * [`Fuel`](../fuel/README.md)
 * KotlinX Coroutines: 1.1.1
 


### PR DESCRIPTION
## Description

Looks like it not changed after copy-paste the android module's readme file.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings