### PR TITLE
Correct RxFuel api surface

### DIFF
--- a/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
+++ b/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
@@ -229,7 +229,7 @@ fun <T : Any> Request.rxObjectTriple(deserializable: Deserializable<T>) = rxResu
  *
  * This wrapper is a [io.reactivex.Single] wrapper that uses onError to signal the error that occurs
  * in the stream. If you wish to receive an Error in the format of [com.github.kittinunf.result.Result],
- * please use [rx] instead.
+ * please use [rx(Request.((R) -> Unit) -> CancellableRequest)] instead.
  *
  * @param resultBlock [() -> R] function that returns [R]
  * @return [Single] the reactive stream for a [Single] with response [R]

--- a/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
+++ b/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
@@ -68,10 +68,24 @@ private fun <T : Any> Request.rxResultTriple(deserializable: Deserializable<T>):
  * Returns a reactive stream for a [Single] value response [ByteArray]
  *
  * @see rxBytes
- * @return [Single<T>] the [ByteArray] wrapped into a [Pair] and [Result]
+ * @return [Single<ByteArray>]
  */
 fun Request.rxResponse() = rxResponseSingle(ByteArrayDeserializer())
+
+/**
+ * Returns a reactive stream for a [Single] value response [ByteArray]
+ *
+ * @see rxBytes
+ * @return [Single<Pair<Response, ByteArray>>] the [ByteArray] wrapped into a [Pair] with [Response]
+ */
 fun Request.rxResponsePair() = rxResponsePair(ByteArrayDeserializer())
+
+/**
+ * Returns a reactive stream for a [Single] value response [ByteArray]
+ *
+ * @see rxBytes
+ * @return [Single<Triple<Request, Response, ByteArray>>] the [ByteArray] wrapped into a [Triple] with [Response] and [Request]
+ */
 fun Request.rxResponseTriple() = rxResponseTriple(ByteArrayDeserializer())
 
 /**
@@ -80,10 +94,28 @@ fun Request.rxResponseTriple() = rxResponseTriple(ByteArrayDeserializer())
  * @see rxString
  *
  * @param charset [Charset] the character set to deserialize with
- * @return [Single<String>] the [String] wrapped into a [Pair] and [Result]
+ * @return [Single<String>]
  */
 fun Request.rxResponseString(charset: Charset = Charsets.UTF_8) = rxResponseSingle(StringDeserializer(charset))
+
+/**
+ * Returns a reactive stream for a [Single] value response [String]
+ *
+ * @see rxString
+ *
+ * @param charset [Charset] the character set to deserialize with
+ * @return [Single<Pair<Response, String>>] the [String] wrapped into a [Pair] with [Response]
+ */
 fun Request.rxResponseStringPair(charset: Charset = Charsets.UTF_8) = rxResponsePair(StringDeserializer(charset))
+
+/**
+ * Returns a reactive stream for a [Single] value response [String]
+ *
+ * @see rxString
+ *
+ * @param charset [Charset] the character set to deserialize with
+ * @return [Single<Triple<Request, Response, String>>] the [String] wrapped into a [Triple] with [Response] and [Request]
+ */
 fun Request.rxResponseStringTriple(charset: Charset = Charsets.UTF_8) = rxResponseTriple(StringDeserializer(charset))
 
 /**
@@ -92,24 +124,56 @@ fun Request.rxResponseStringTriple(charset: Charset = Charsets.UTF_8) = rxRespon
  * @see rxObject
  *
  * @param deserializable [Deserializable<T>] something that can deserialize the [Response] to a [T]
- * @return [Single<T>] the [T] wrapped into a [Pair] and [Result]
+ * @return [Single<T>]
  */
 fun <T : Any> Request.rxResponseObject(deserializable: Deserializable<T>) = rxResponseSingle(deserializable)
+
+/**
+ * Returns a reactive stream for a [Single] value response object [T]
+ *
+ * @see rxObject
+ *
+ * @param deserializable [Deserializable<T>] something that can deserialize the [Response] to a [T]
+ * @return [Single<Pair<Response, T>>] the [T] wrapped into a [Pair] with [Response]
+ */
 fun <T : Any> Request.rxResponseObjectPair(deserializable: Deserializable<T>) = rxResponsePair(deserializable)
+
+/**
+ * Returns a reactive stream for a [Single] value response object [T]
+ *
+ * @see rxObject
+ *
+ * @param deserializable [Deserializable<T>] something that can deserialize the [Response] to a [T]
+ * @return [Single<Triple<Request, Response, T>>] the [T] wrapped into a [Triple] with [Response] and [Request]
+ */
 fun <T : Any> Request.rxResponseObjectTriple(deserializable: Deserializable<T>) = rxResponseTriple(deserializable)
 
 /**
- * Returns a reactive stream for a [Single] value response [ByteArray]
+ * Returns a reactive stream for a [Single] value result of [ByteArray]
  *
  * @see rxResponse
  * @return [Single<Result<ByteArray, FuelError>>] the [ByteArray] wrapped into a [Result]
  */
 fun Request.rxBytes() = rxResultSingle(ByteArrayDeserializer())
+
+/**
+ * Returns a reactive stream for a [Single] value result of [ByteArray]
+ *
+ * @see rxResponse
+ * @return [Single<Pair<Response, Result<ByteArray, FuelError>>>] the [ByteArray] wrapped into a [Result] together with a [Pair] with [Response]
+ */
 fun Request.rxBytesPair() = rxResultPair(ByteArrayDeserializer())
+
+/**
+ * Returns a reactive stream for a [Single] value result of [ByteArray]
+ *
+ * @see rxResponse
+ * @return [Single<Triple<Request, Response, Result<ByteArray, FuelError>>>] the [ByteArray] wrapped into a [Result] together with a [Triple] with [Response] and [Request]
+ */
 fun Request.rxBytesTriple() = rxResultTriple(ByteArrayDeserializer())
 
 /**
- * Returns a reactive stream for a [Single] value response [ByteArray]
+ * Returns a reactive stream for a [Single] value result of [ByteArray]
  *
  * @see rxResponseString
  *
@@ -117,11 +181,25 @@ fun Request.rxBytesTriple() = rxResultTriple(ByteArrayDeserializer())
  * @return [Single<Result<String, FuelError>>] the [String] wrapped into a [Result]
  */
 fun Request.rxString(charset: Charset = Charsets.UTF_8) = rxResultSingle(StringDeserializer(charset))
+
+/**
+ * Returns a reactive stream for a [Single] value result of [String]
+ *
+ * @see rxResponseString
+ * @return [Single<Pair<Response, Result<String, FuelError>>>] the [String] wrapped into a [Result] together with a [Pair] with [Response]
+ */
 fun Request.rxStringPair(charset: Charset = Charsets.UTF_8) = rxResultPair(StringDeserializer(charset))
+
+/**
+ * Returns a reactive stream for a [Single] value result of [String]
+ *
+ * @see rxResponseString
+ * @return [Single<Triple<Request, Response, Result<String, FuelError>>>] the [String] wrapped into a [Result] together with a [Triple] with [Response] and [Request]
+ */
 fun Request.rxStringTriple(charset: Charset = Charsets.UTF_8) = rxResultTriple(StringDeserializer(charset))
 
 /**
- * Returns a reactive stream for a [Single] value response [T]
+ * Returns a reactive stream for a [Single] value result of [T]
  *
  * @see rxResponseObject
  *
@@ -129,7 +207,21 @@ fun Request.rxStringTriple(charset: Charset = Charsets.UTF_8) = rxResultTriple(S
  * @return [Single<Result<T, FuelError>>] the [T] wrapped into a [Result]
  */
 fun <T : Any> Request.rxObject(deserializable: Deserializable<T>) = rxResultSingle(deserializable)
+
+/**
+ * Returns a reactive stream for a [Single] value result of [T]
+ *
+ * @see rxResponseObject
+ * @return [Single<Pair<Response, Result<T, FuelError>>>] the [T] wrapped into a [Result] together with a [Pair] with [Response]
+ */
 fun <T : Any> Request.rxObjectPair(deserializable: Deserializable<T>) = rxResultPair(deserializable)
+
+/**
+ * Returns a reactive stream for a [Single] value result of [T]
+ *
+ * @see rxResponseObject
+ * @return [Single<Triple<Request, Response, Result<T, FuelError>>>] the [T] wrapped into a [Result] together with a [Triple] with [Response] and [Request]
+ */
 fun <T : Any> Request.rxObjectTriple(deserializable: Deserializable<T>) = rxResultTriple(deserializable)
 
 /**

--- a/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
+++ b/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
@@ -7,6 +7,7 @@ import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.ResponseDeserializable
 import com.github.kittinunf.fuel.rx.rxBytes
 import com.github.kittinunf.fuel.rx.rxBytesPair
+import com.github.kittinunf.fuel.rx.rxBytesTriple
 import com.github.kittinunf.fuel.rx.rxObject
 import com.github.kittinunf.fuel.rx.rxResponse
 import com.github.kittinunf.fuel.rx.rxResponseObject
@@ -257,7 +258,7 @@ class RxFuelTest : MockHttpTestCase() {
             response = mock.response().withStatusCode(HttpURLConnection.HTTP_OK).withBody(ByteArray(555) { 0 })
         )
 
-        val data = Fuel.get(mock.path("bytes"))
+        val (resp, result) = Fuel.get(mock.path("bytes"))
             .rxBytesPair()
             .test()
             .apply { awaitTerminalEvent() }
@@ -266,10 +267,35 @@ class RxFuelTest : MockHttpTestCase() {
             .assertComplete()
             .values()[0]
 
-        assertThat(data, notNullValue())
-        assertThat(data.first.statusCode, equalTo(HttpURLConnection.HTTP_OK))
-        assertThat(data.second as Result.Success, isA(Result.Success::class.java))
-        val (value, error) = data
+        assertThat(resp, notNullValue())
+        assertThat(resp.statusCode, equalTo(HttpURLConnection.HTTP_OK))
+        assertThat(result as Result.Success, isA(Result.Success::class.java))
+        val (value, error) = result
+        assertThat(value, notNullValue())
+        assertThat(error, nullValue())
+    }
+
+    @Test
+    fun rxBytesTriple() {
+        mock.chain(
+                request = mock.request().withPath("/bytes"),
+                response = mock.response().withStatusCode(HttpURLConnection.HTTP_OK).withBody(ByteArray(555) { 0 })
+        )
+
+        val (req, resp, result) = Fuel.get(mock.path("bytes"))
+                .rxBytesTriple()
+                .test()
+                .apply { awaitTerminalEvent() }
+                .assertNoErrors()
+                .assertValueCount(1)
+                .assertComplete()
+                .values()[0]
+
+        assertThat(req, notNullValue())
+        assertThat(resp, notNullValue())
+        assertThat(resp.statusCode, equalTo(HttpURLConnection.HTTP_OK))
+        assertThat(result as Result.Success, isA(Result.Success::class.java))
+        val (value, error) = result
         assertThat(value, notNullValue())
         assertThat(error, nullValue())
     }

--- a/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
+++ b/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
@@ -344,7 +344,7 @@ class RxFuelTest : MockHttpTestCase() {
         assertThat(data, notNullValue())
         assertThat(data.first.statusCode, equalTo(HttpURLConnection.HTTP_OK))
         assertThat(data.second as Result.Success, isA(Result.Success::class.java))
-        val (value, error) = data
+        val (value, error) = data.second
         assertThat(value, notNullValue())
         assertThat(error, nullValue())
     }
@@ -369,7 +369,7 @@ class RxFuelTest : MockHttpTestCase() {
         assertThat(data.first, notNullValue())
         assertThat(data.second.statusCode, equalTo(HttpURLConnection.HTTP_OK))
         assertThat(data.third as Result.Success, isA(Result.Success::class.java))
-        val (value, error) = data
+        val (value, error) = data.third
         assertThat(value, notNullValue())
         assertThat(error, nullValue())
     }

--- a/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
+++ b/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
@@ -19,6 +19,8 @@ import com.github.kittinunf.fuel.rx.rxResponseStringPair
 import com.github.kittinunf.fuel.rx.rxResponseStringTriple
 import com.github.kittinunf.fuel.rx.rxResponseTriple
 import com.github.kittinunf.fuel.rx.rxString
+import com.github.kittinunf.fuel.rx.rxStringPair
+import com.github.kittinunf.fuel.rx.rxStringTriple
 import com.github.kittinunf.fuel.test.MockHttpTestCase
 import com.github.kittinunf.result.Result
 import org.hamcrest.CoreMatchers.containsString
@@ -323,6 +325,54 @@ class RxFuelTest : MockHttpTestCase() {
         assertThat(error, nullValue())
     }
 
+    @Test
+    fun rxStringPair() {
+        mock.chain(
+            request = mock.request().withPath("/user-agent"),
+            response = mock.reflect()
+        )
+
+        val data = Fuel.get(mock.path("user-agent"))
+            .rxStringPair()
+            .test()
+            .apply { awaitTerminalEvent() }
+            .assertNoErrors()
+            .assertValueCount(1)
+            .assertComplete()
+            .values()[0]
+
+        assertThat(data, notNullValue())
+        assertThat(data.first.statusCode, equalTo(HttpURLConnection.HTTP_OK))
+        assertThat(data.second as Result.Success, isA(Result.Success::class.java))
+        val (value, error) = data
+        assertThat(value, notNullValue())
+        assertThat(error, nullValue())
+    }
+
+    @Test
+    fun rxStringTriple() {
+        mock.chain(
+                request = mock.request().withPath("/user-agent"),
+                response = mock.reflect()
+        )
+
+        val data = Fuel.get(mock.path("user-agent"))
+                .rxStringTriple()
+                .test()
+                .apply { awaitTerminalEvent() }
+                .assertNoErrors()
+                .assertValueCount(1)
+                .assertComplete()
+                .values()[0]
+
+        assertThat(data, notNullValue())
+        assertThat(data.first, notNullValue())
+        assertThat(data.second.statusCode, equalTo(HttpURLConnection.HTTP_OK))
+        assertThat(data.third as Result.Success, isA(Result.Success::class.java))
+        val (value, error) = data
+        assertThat(value, notNullValue())
+        assertThat(error, nullValue())
+    }
     @Test
     fun rxStringWithError() {
         mock.chain(


### PR DESCRIPTION
### What's in this PR?

This PR is an attempt to correct our RxFuel exposing api. It apparently misses the `Single<Result<..., Fuel>>` counterpart. With this PR, we should have the correct and complete interfaces that we want to expose. 

In summary, we will have api as follows;

### rxResponse (`Single<T>`)

| Type\API  | Response | Pair<Respone, Value> | Triple<Request, Response, Value>
| ------------- | ------------- | ------------- | ------------- |
| Byte  | `rxResponse`  | `rxResponsePair` | `rxResponseTriple` |
| String  | `rxResponseString`  | `rxResponseStringPair` | `rxResponseStringTriple` |
| T  | `rxResponseObject`  | `rxResponesObjectPair` | `rxResponseObjectTriple`

In the above methods, an error notification will be emitting through `Single::onError`

### rx<T> (`Single<Result<>>`)
| Type\API  | Result<Byte, > | Pair<Respone, Result<String, >> | Triple<Request, Response, Result<String, >>
| ------------- | ------------- | ------------- | ------------- |
| Byte  | `rxBytes`  | `rxBytesPair` | `rxBytesTriple` |
| String  | `rxString`  | `rxStringPair` | `rxStringTriple` |
| T  | `rxObject`  | `rxObjectPair` | `rxObjectTriple`

In the above methods, an error notification will be emitting through `Single::onNext` with `Result.Failure`

PS. I feel that having 9 * 2 = 18 methods are a bit too many 😹  ... Shall we try to reduce them in the next major release?