### PR TITLE
:sparkles: Add support for custom Gson instances

### DIFF
--- a/fuel-gson/src/main/kotlin/com/github/kittinunf/fuel/gson/FuelGson.kt
+++ b/fuel-gson/src/main/kotlin/com/github/kittinunf/fuel/gson/FuelGson.kt
@@ -73,15 +73,11 @@ inline fun <reified T : Any> Request.responseObject(gson: Gson) =
  *
  * @return [ResponseDeserializable<T>] the deserializer
  */
-inline fun <reified T : Any> gsonDeserializerOf(clazz: Class<T>) = object : ResponseDeserializable<T> {
-    override fun deserialize(reader: Reader): T? = Gson().fromJson<T>(reader, clazz)
-}
+inline fun <reified T : Any> gsonDeserializerOf(clazz: Class<T>) = gsonDeserializer<T>()
 
-inline fun <reified T : Any> gsonDeserializer(gson: Gson) = object : ResponseDeserializable<T> {
+inline fun <reified T : Any> gsonDeserializer(gson: Gson = Gson()) = object : ResponseDeserializable<T> {
     override fun deserialize(reader: Reader): T? = gson.fromJson<T>(reader, object : TypeToken<T>() {}.type)
 }
-
-inline fun <reified T : Any> gsonDeserializer() = gsonDeserializer<T>(Gson())
 
 /**
  * Serializes [src] to json and sets the body as application/json

--- a/fuel-gson/src/main/kotlin/com/github/kittinunf/fuel/gson/FuelGson.kt
+++ b/fuel-gson/src/main/kotlin/com/github/kittinunf/fuel/gson/FuelGson.kt
@@ -22,6 +22,16 @@ inline fun <reified T : Any> Request.responseObject(noinline handler: ResponseRe
     response(gsonDeserializer(), handler)
 
 /**
+ * Asynchronously gets a response object of [T] wrapped in [Result] via [handler] using custom [Gson] instance
+ *
+ * @param gson [Gson] custom Gson deserializer instance
+ * @param handler [ResponseResultHandler<T>] the handler that is called upon success
+ * @return [CancellableRequest] request that can be cancelled
+ */
+inline fun <reified T : Any> Request.responseObject(gson: Gson, noinline handler: ResponseResultHandler<T>) =
+    response(gsonDeserializer(gson), handler)
+
+/**
  * Asynchronously gets a response object of [T] or [com.github.kittinunf.fuel.core.FuelError] via [handler]
  *
  * @param handler [Handle<T>] the handler that is called upon success
@@ -29,6 +39,17 @@ inline fun <reified T : Any> Request.responseObject(noinline handler: ResponseRe
  */
 inline fun <reified T : Any> Request.responseObject(handler: ResponseHandler<T>) =
     response(gsonDeserializer(), handler)
+
+/**
+ * Asynchronously gets a response object of [T] or [com.github.kittinunf.fuel.core.FuelError] via [handler]
+ *  using custom [Gson] instance
+ *
+ * @param gson [Gson] custom Gson deserializer instance
+ * @param handler [Handle<T>] the handler that is called upon success
+ * @return [CancellableRequest] request that can be cancelled
+ */
+inline fun <reified T : Any> Request.responseObject(gson: Gson, handler: ResponseHandler<T>) =
+    response(gsonDeserializer(gson), handler)
 
 /**
  * Synchronously get a response object of [T]
@@ -39,6 +60,15 @@ inline fun <reified T : Any> Request.responseObject() =
     response(gsonDeserializer<T>())
 
 /**
+ * Synchronously get a response object of [T]
+ *
+ * @param gson [Gson] custom Gson deserializer instance
+ * @return [Triple<Request, Response, Result<T, FuelError>>] the deserialized result
+ */
+inline fun <reified T : Any> Request.responseObject(gson: Gson) =
+    response(gsonDeserializer<T>(gson))
+
+/**
  * Generate a [ResponseDeserializable<T>] that can deserialize json of [T]
  *
  * @return [ResponseDeserializable<T>] the deserializer
@@ -47,9 +77,23 @@ inline fun <reified T : Any> gsonDeserializerOf(clazz: Class<T>) = object : Resp
     override fun deserialize(reader: Reader): T? = Gson().fromJson<T>(reader, clazz)
 }
 
-inline fun <reified T : Any> gsonDeserializer() = object : ResponseDeserializable<T> {
-    override fun deserialize(reader: Reader): T? = Gson().fromJson<T>(reader, object : TypeToken<T>() {}.type)
+inline fun <reified T : Any> gsonDeserializer(gson: Gson) = object : ResponseDeserializable<T> {
+    override fun deserialize(reader: Reader): T? = gson.fromJson<T>(reader, object : TypeToken<T>() {}.type)
 }
+
+inline fun <reified T : Any> gsonDeserializer() = gsonDeserializer<T>(Gson())
+
+/**
+ * Serializes [src] to json and sets the body as application/json
+ *
+ * @param src [Any] the source to serialize
+ * @param gson [Gson] custom Gson deserializer instance
+ * @return [Request] the modified request
+ */
+inline fun <reified T : Any> Request.jsonBody(src: T, gson: Gson) =
+    this.jsonBody(gson.toJson(src, object : TypeToken<T>() {}.type)
+        .also { Fuel.trace { "serialized $it" } } as String
+    )
 
 /**
  * Serializes [src] to json and sets the body as application/json
@@ -57,7 +101,4 @@ inline fun <reified T : Any> gsonDeserializer() = object : ResponseDeserializabl
  * @param src [Any] the source to serialize
  * @return [Request] the modified request
  */
-inline fun <reified T : Any> Request.jsonBody(src: T) =
-    this.jsonBody(Gson().toJson(src, object : TypeToken<T>() {}.type)
-        .also { Fuel.trace { "serialized $it" } } as String
-    )
+inline fun <reified T : Any> Request.jsonBody(src: T) = this.jsonBody(src, Gson())

--- a/fuel-gson/src/test/kotlin/com/github/kittinunf/fuel/FuelGsonTest.kt
+++ b/fuel-gson/src/test/kotlin/com/github/kittinunf/fuel/FuelGsonTest.kt
@@ -11,6 +11,13 @@ import com.github.kittinunf.fuel.gson.responseObject
 import com.github.kittinunf.fuel.test.MockHttpTestCase
 import com.github.kittinunf.fuel.test.MockReflected
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
 import com.google.gson.reflect.TypeToken
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
@@ -18,6 +25,7 @@ import org.hamcrest.CoreMatchers.notNullValue
 import org.junit.Assert.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
+import java.lang.reflect.Type
 import java.net.HttpURLConnection
 
 private typealias IssuesList = List<IssueInfo>
@@ -29,6 +37,33 @@ private data class IssueInfo(
 ) {
     fun specialMethod() = "$id: $title"
 }
+
+private sealed class IssueType {
+    object Bug : IssueType()
+    object Feature : IssueType()
+
+    companion object : JsonSerializer<IssueType>, JsonDeserializer<IssueType> {
+        override fun serialize(src: IssueType, typeOfSrc: Type, context: JsonSerializationContext): JsonElement =
+            when (src) {
+                is Bug -> JsonPrimitive("bug")
+                is Feature -> JsonPrimitive("feature")
+            }
+
+        override fun deserialize(json: JsonElement, typeOfT: Type?, context: JsonDeserializationContext?): IssueType =
+            if (json.isJsonPrimitive() && (json as JsonPrimitive).isString) {
+                when (json.asString) {
+                    "bug" -> Bug
+                    "feature" -> Feature
+                    else -> throw Error("Not a bug or a feature, what is it?")
+                }
+            } else {
+                throw Error("String expected")
+            }
+    }
+}
+
+private typealias IssueTypeList = List<IssueType>
+
 
 class FuelGsonTest : MockHttpTestCase() {
 
@@ -251,5 +286,29 @@ class FuelGsonTest : MockHttpTestCase() {
         assertThat("Expected issues, actual error $error", issues, notNullValue())
         assertThat(issues.size, equalTo(data.size))
         assertThat(issues.first().specialMethod(), equalTo("1: issue 1"))
+    }
+
+    @Test
+    fun testCustomGsonInstance() {
+        val gson = GsonBuilder()
+            .registerTypeAdapter(IssueType::class.java, IssueType.Companion)
+            .create()
+
+        val data = listOf(
+            IssueType.Bug,
+            IssueType.Feature
+        )
+
+        val (_, _, result) = reflectedRequest(Method.POST, "json-body")
+            .jsonBody(data, gson)
+            .responseObject<MockReflected>()
+
+        val (reflected, error) = result
+        val body = reflected!!.body!!.string!!
+        val types: IssueTypeList = gson.fromJson(body, object : TypeToken<IssueTypeList>() {}.type)
+        assertThat("Expected types, actual error $error", types, notNullValue())
+        assertThat(body, equalTo("[\"bug\",\"feature\"]"))
+        assertThat(types.size, equalTo(data.size))
+        assertThat(types.first(), equalTo<IssueType>(IssueType.Bug))
     }
 }

--- a/fuel-gson/src/test/kotlin/com/github/kittinunf/fuel/FuelGsonTest.kt
+++ b/fuel-gson/src/test/kotlin/com/github/kittinunf/fuel/FuelGsonTest.kt
@@ -64,7 +64,6 @@ private sealed class IssueType {
 
 private typealias IssueTypeList = List<IssueType>
 
-
 class FuelGsonTest : MockHttpTestCase() {
 
     data class HttpBinUserAgentModel(var userAgent: String = "")


### PR DESCRIPTION
Add API support for passing custom Gson instances for serializing
request entities or deserializing response body

## Description

Current `fuel-gson` implementation have Gson instances hardcoded, I've added few overrides to existing functions to be able to pass a custom Gson instance.

For some of new functions - default values may be used (vs override), but I'm not sure which one is safer for binary compatibility, hopefully you may give me a hint here, ex:

```kotlin
inline fun <reified T : Any> Request.jsonBody(src: T, gson: Gson) = ...

inline fun <reified T : Any> Request.jsonBody(src: T) = this.jsonBody(src, Gson())
```

vs

```kotlin
inline fun <reified T : Any> Request.jsonBody(src: T, gson: Gson = Gson()) = 
```


## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
