### PR TITLE
Fix content length parameter for InlineDataPart

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
@@ -100,7 +100,7 @@ data class InlineDataPart(
     override val contentDisposition: String = "form-data; name=\"$name\"${if (filename != null) "; filename=\"$filename\"" else "" }"
 ) : DataPart() {
     override fun inputStream() = content.byteInputStream()
-    override val contentLength get() = content.toByteArray().size.toLong()
+    override val contentLength get() = content.toByteArray(Charsets.UTF_8).size.toLong()
 }
 
 /**

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
@@ -100,7 +100,7 @@ data class InlineDataPart(
     override val contentDisposition: String = "form-data; name=\"$name\"${if (filename != null) "; filename=\"$filename\"" else "" }"
 ) : DataPart() {
     override fun inputStream() = content.byteInputStream()
-    override val contentLength get() = content.length.toLong()
+    override val contentLength get() = content.toByteArray().size
 }
 
 /**

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/DataPart.kt
@@ -100,7 +100,7 @@ data class InlineDataPart(
     override val contentDisposition: String = "form-data; name=\"$name\"${if (filename != null) "; filename=\"$filename\"" else "" }"
 ) : DataPart() {
     override fun inputStream() = content.byteInputStream()
-    override val contentLength get() = content.toByteArray().size
+    override val contentLength get() = content.toByteArray().size.toLong()
 }
 
 /**


### PR DESCRIPTION
## Description
Hi Fuel team, right now we are using your library as main networking tool and we have several multipart data request for uploading images. 
What I have found, that in your InlineDataPart you are using `content.length.toLong()` which is not right. For example, you can have emoji in your content and measuing size of the DataPart by string length doesn't seem proper.
So instead I changed measuring size of the InlineDataPart to `content.toByteArray().size`

I didn't find a issue related to this problem and created pull request right away. I hope you will find and useful and merge into the master, because its really crucial for us.

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested it with several strings with emoji. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
