### PR TITLE
Catch Forge's MissingAttributeError on FuelError

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -117,7 +117,7 @@ object AndroidX {
 
 // Modules dependencies
 object Forge {
-    const val version = "0.3.0"
+    const val version = "1.0.0-alpha2"
     const val dependency = "com.github.kittinunf.forge:forge:$version"
 }
 

--- a/fuel-forge/src/main/java/com/github/kittinunf/fuel/forge/FuelForge.kt
+++ b/fuel-forge/src/main/java/com/github/kittinunf/fuel/forge/FuelForge.kt
@@ -29,11 +29,10 @@ inline fun <reified T : Any> Request.responseObjects(noinline deserializer: JSON
 
 fun <T : Any> forgeDeserializerOf(deserializer: JSON.() -> DeserializedResult<T>) = object : ResponseDeserializable<T> {
     override fun deserialize(content: String): T? {
-        val forge =  Forge.modelFromJson(content, deserializer)
-        forge.component2()?.let {
-            throw it
+        when (val result = Forge.modelFromJson(content, deserializer)) {
+            is DeserializedResult.Success -> return result.value
+            is DeserializedResult.Failure -> throw result.error
         }
-        return forge.component1()
     }
 }
 fun <T : Any> forgesDeserializerOf(deserializer: JSON.() -> DeserializedResult<T>) = object : ResponseDeserializable<List<T>> {

--- a/fuel-forge/src/main/java/com/github/kittinunf/fuel/forge/FuelForge.kt
+++ b/fuel-forge/src/main/java/com/github/kittinunf/fuel/forge/FuelForge.kt
@@ -28,7 +28,13 @@ inline fun <reified T : Any> Request.responseObject(noinline deserializer: JSON.
 inline fun <reified T : Any> Request.responseObjects(noinline deserializer: JSON.() -> DeserializedResult<T>) = response(forgesDeserializerOf(deserializer))
 
 fun <T : Any> forgeDeserializerOf(deserializer: JSON.() -> DeserializedResult<T>) = object : ResponseDeserializable<T> {
-    override fun deserialize(content: String): T? = Forge.modelFromJson(content, deserializer).component1()
+    override fun deserialize(content: String): T? {
+        val forge =  Forge.modelFromJson(content, deserializer)
+        forge.component2()?.let {
+            throw it
+        }
+        return forge.component1()
+    }
 }
 fun <T : Any> forgesDeserializerOf(deserializer: JSON.() -> DeserializedResult<T>) = object : ResponseDeserializable<List<T>> {
     override fun deserialize(content: String): List<T>? = Forge.modelsFromJson(content, deserializer).map { it.get<T>() }


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

Some how, Forge Error didn't catch property on FuelError. 

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In case you did not include tests describe why you and how you have verified the
changes, with instructions so we can reproduce. If you have added comprehensive
tests for your changes, you may omit this section.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
