### PR TITLE
Fix Travis CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: android
-jdk: oraclejdk8
+jdk: openjdk8
 env:
   - REVIEWDOG_VERSION=0.9.11
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: android
-
+jdk: oraclejdk8
 env:
   - REVIEWDOG_VERSION=0.9.11
-  
-jdk:
-  - oraclejdk8
 
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ android:
   licenses:
     - 'android-sdk-license-.+'
 
-before_install:
- - yes | sdkmanager "platforms;android-28"
-
 cache:
   directories:
     - $HOME/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-dist: xenial
 language: android
-jdk: openjdk8
+dist: trusty
+
 env:
   - REVIEWDOG_VERSION=0.9.11
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: android
 jdk: openjdk8
 env:


### PR DESCRIPTION
## Description

yes | sdkmanager "platforms;android-28"
/home/travis/.travis/functions: line 104: sdkmanager: command not found
The command "yes | sdkmanager "platforms;android-28"" failed and exited with 127 during .

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In case you did not include tests describe why you and how you have verified the
changes, with instructions so we can reproduce. If you have added comprehensive
tests for your changes, you may omit this section.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
