### PR TITLE
Fix #667: Don't buffer output stream when no progress callback is given

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Progress.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Progress.kt
@@ -13,6 +13,8 @@ data class Progress(private val handlers: MutableCollection<ProgressCallback> = 
         return this
     }
 
+    fun isNotSet(): Boolean = handlers.isEmpty()
+
     override operator fun invoke(readBytes: Long, totalBytes: Long) {
         handlers.forEach {
             it.invoke(readBytes, totalBytes)


### PR DESCRIPTION
## Description

This fixes the slowness described in #667 by checking if a progress callback is set. If no progress callbacks are given, the outputstream will not be buffered.

## Type of change

Check all that apply

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
