### PR TITLE
Fix #667: use wrapped OutputStream batch write in ProgressOutputStrea…

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/ProgressOutputStream.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/ProgressOutputStream.kt
@@ -26,7 +26,7 @@ class ProgressOutputStream(stream: OutputStream, val onProgress: WriteProgress) 
     // function is called, instead of relying on some arbitrary, but fake, progress.
     //
     override fun write(b: ByteArray?, off: Int, len: Int) {
-        super.write(b, off, len)
+        out.write(b, off, len)
         position += len
         onProgress.invoke(position)
     }


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

<!-- Include a summary of the change and which [issue](https://github.com/kittinunf/Fuel/issues)
this fixes. Also, include relevant motivation and context. List any dependencies
that are required for this change and why they are necessary. -->

This fixes the slowness described in #667 even if progress callback is used - `ProgressOutputStream` now uses wrapped ` OutputStream` `write(byte[] b, int off, int len)` directly as `FilterOutputStream` implementation is not efficient .

<!-- Fixes #0
Fixes #0 -->

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
