### PR TITLE
[fuel-core] Use StreamingMode only in UploadRequest

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.core.Method
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.requests.DefaultBody
+import com.github.kittinunf.fuel.core.requests.UploadRequest
 import com.github.kittinunf.fuel.core.requests.isCancelled
 import com.github.kittinunf.fuel.util.ProgressInputStream
 import com.github.kittinunf.fuel.util.ProgressOutputStream

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -229,12 +229,14 @@ class HttpClient(
         }
 
         val contentLength = body.length
-        if (contentLength != null && contentLength != -1L) {
-            // The content has a known length, so no need to chunk
-            connection.setFixedLengthStreamingMode(contentLength.toLong())
-        } else {
-            // The content doesn't have a known length, so turn it into chunked
-            connection.setChunkedStreamingMode(4096)
+        if (request is UploadRequest) {
+            if (contentLength != null && contentLength != -1L) {
+                // The content has a known length, so no need to chunk
+                connection.setFixedLengthStreamingMode(contentLength.toLong())
+            } else {
+                // The content doesn't have a known length, so turn it into chunked
+                connection.setChunkedStreamingMode(4096)
+            }
         }
 
         val noProgressHandler = request.executionOptions.requestProgress.isNotSet()


### PR DESCRIPTION
When StreamingMode is used cannot get response data from status code 401. https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html#setFixedLengthStreamingMode-long-

In Fuel version 1.X.X you can get the response data, that's because StreamingMode was only used for UploadRequest.

<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

<!-- Include a summary of the change and which [issue](https://github.com/kittinunf/Fuel/issues)
this fixes. Also, include relevant motivation and context. List any dependencies
that are required for this change and why they are necessary. -->

<!-- Fixes #0
Fixes #0 -->

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In case you did not include tests describe why you and how you have verified the
changes, with instructions so we can reproduce. If you have added comprehensive
tests for your changes, you may omit this section.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
