### PR TITLE
:art: Add EmptyDeserializer and corresponding extensions methods

### DIFF
--- a/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
+++ b/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
@@ -40,7 +40,7 @@ suspend inline fun <T : Any, U : Deserializable<T>> Request.await(deserializable
  * @param scope [CoroutineContext] the context to run within
  */
 @Throws
-suspend fun Request.awaitIgnored(scope: CoroutineContext = Dispatchers.IO): Unit = await(EmptyDeserializer, scope)
+suspend fun Request.awaitUnit(scope: CoroutineContext = Dispatchers.IO): Unit = await(EmptyDeserializer, scope)
 
 /**
  * Await the [T] using a [scope], defaulting to [Dispatchers.IO], wrapped in [Result]

--- a/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
+++ b/fuel-coroutines/src/main/kotlin/com/github/kittinunf/fuel/coroutines/Coroutines.kt
@@ -10,6 +10,7 @@ import com.github.kittinunf.fuel.core.awaitResponse
 import com.github.kittinunf.fuel.core.awaitResponseResult
 import com.github.kittinunf.fuel.core.awaitResult
 import com.github.kittinunf.fuel.core.deserializers.ByteArrayDeserializer
+import com.github.kittinunf.fuel.core.deserializers.EmptyDeserializer
 import com.github.kittinunf.fuel.core.deserializers.StringDeserializer
 import com.github.kittinunf.result.Result
 import kotlinx.coroutines.Dispatchers
@@ -30,6 +31,16 @@ import kotlin.coroutines.CoroutineContext
 @Throws
 suspend inline fun <T : Any, U : Deserializable<T>> Request.await(deserializable: U, scope: CoroutineContext = Dispatchers.IO): T =
     withContext(scope) { await(deserializable) }
+
+/**
+ * Await the task finish without getting result using a [scope], defaulting to [Dispatchers.IO]
+ *
+ * @throws FuelError if deserialization fails, if network fails, other internal exception is thrown
+ *
+ * @param scope [CoroutineContext] the context to run within
+ */
+@Throws
+suspend fun Request.awaitIgnored(scope: CoroutineContext = Dispatchers.IO): Unit = await(EmptyDeserializer, scope)
 
 /**
  * Await the [T] using a [scope], defaulting to [Dispatchers.IO], wrapped in [Result]

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/ObjectTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/ObjectTest.kt
@@ -121,9 +121,9 @@ class ObjectTest : MockHttpTestCase() {
     }
 
     @Test
-    fun awaitIgnored() = runBlocking {
+    fun awaitUnit() = runBlocking {
         runCatching {
-            val data = randomUuid().awaitIgnored()
+            val data = randomUuid().awaitUnit()
             assertThat(data, notNullValue())
             assertThat(data, equalTo(Unit))
         }.getOrElse {

--- a/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/ObjectTest.kt
+++ b/fuel-coroutines/src/test/kotlin/com/github/kittinunf/fuel/coroutines/ObjectTest.kt
@@ -121,6 +121,17 @@ class ObjectTest : MockHttpTestCase() {
     }
 
     @Test
+    fun awaitIgnored() = runBlocking {
+        runCatching {
+            val data = randomUuid().awaitIgnored()
+            assertThat(data, notNullValue())
+            assertThat(data, equalTo(Unit))
+        }.getOrElse {
+            fail("Expected pass, actual error $it")
+        }
+    }
+
+    @Test
     fun captureDeserializationException() = runBlocking {
 
         val (request, response, result) = reflectedRequest(Method.GET, "reflected")

--- a/fuel-reactor/src/main/kotlin/com/github/kittinunf/fuel/reactor/Reactor.kt
+++ b/fuel-reactor/src/main/kotlin/com/github/kittinunf/fuel/reactor/Reactor.kt
@@ -99,4 +99,4 @@ fun <T : Any> Request.monoResultObject(mapper: Deserializable<T>): Mono<Result<T
 /**
  * Get a complete signal(success with [Unit]) via a [MonoSink.success], or any [FuelError] via [MonoSink.error]
  */
-fun Request.monoIgnored(): Mono<Unit> = monoResultFold(EmptyDeserializer)
+fun Request.monoUnit(): Mono<Unit> = monoResultFold(EmptyDeserializer)

--- a/fuel-reactor/src/main/kotlin/com/github/kittinunf/fuel/reactor/Reactor.kt
+++ b/fuel-reactor/src/main/kotlin/com/github/kittinunf/fuel/reactor/Reactor.kt
@@ -1,10 +1,14 @@
 package com.github.kittinunf.fuel.reactor
 
-import com.github.kittinunf.fuel.core.*
+import com.github.kittinunf.fuel.core.Deserializable
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.deserializers.ByteArrayDeserializer
 import com.github.kittinunf.fuel.core.deserializers.EmptyDeserializer
 import com.github.kittinunf.fuel.core.deserializers.StringDeserializer
 import com.github.kittinunf.fuel.core.requests.CancellableRequest
+import com.github.kittinunf.fuel.core.response
 import com.github.kittinunf.result.Result
 import reactor.core.publisher.Mono
 import reactor.core.publisher.MonoSink

--- a/fuel-reactor/src/main/kotlin/com/github/kittinunf/fuel/reactor/Reactor.kt
+++ b/fuel-reactor/src/main/kotlin/com/github/kittinunf/fuel/reactor/Reactor.kt
@@ -1,13 +1,10 @@
 package com.github.kittinunf.fuel.reactor
 
-import com.github.kittinunf.fuel.core.Deserializable
-import com.github.kittinunf.fuel.core.FuelError
-import com.github.kittinunf.fuel.core.Request
-import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.fuel.core.*
 import com.github.kittinunf.fuel.core.deserializers.ByteArrayDeserializer
+import com.github.kittinunf.fuel.core.deserializers.EmptyDeserializer
 import com.github.kittinunf.fuel.core.deserializers.StringDeserializer
 import com.github.kittinunf.fuel.core.requests.CancellableRequest
-import com.github.kittinunf.fuel.core.response
 import com.github.kittinunf.result.Result
 import reactor.core.publisher.Mono
 import reactor.core.publisher.MonoSink
@@ -98,3 +95,8 @@ fun Request.monoResultString(charset: Charset = Charsets.UTF_8): Mono<Result<Str
  */
 fun <T : Any> Request.monoResultObject(mapper: Deserializable<T>): Mono<Result<T, FuelError>> =
     monoResultUnFolded(mapper)
+
+/**
+ * Get a complete signal(success with [Unit]) via a [MonoSink.success], or any [FuelError] via [MonoSink.error]
+ */
+fun Request.monoIgnored(): Mono<Unit> = monoResultFold(EmptyDeserializer)

--- a/fuel-reactor/src/test/kotlin/com/github/kittinunf/fuel/reactor/ReactorTest.kt
+++ b/fuel-reactor/src/test/kotlin/com/github/kittinunf/fuel/reactor/ReactorTest.kt
@@ -209,7 +209,7 @@ class ReactorTest : MockHttpTestCase() {
             response = mock.response().withBody("127.0.0.1")
         )
 
-        Fuel.get(mock.path("ip")).monoIgnored()
+        Fuel.get(mock.path("ip")).monoUnit()
             .test()
             .assertNext { assertThat(it, equalTo(Unit)) }
             .verifyComplete()

--- a/fuel-reactor/src/test/kotlin/com/github/kittinunf/fuel/reactor/ReactorTest.kt
+++ b/fuel-reactor/src/test/kotlin/com/github/kittinunf/fuel/reactor/ReactorTest.kt
@@ -202,6 +202,19 @@ class ReactorTest : MockHttpTestCase() {
         assertThat(running.isCancelled, equalTo(true))
     }
 
+    @Test
+    fun monoUnit() {
+        mock.chain(
+            request = mock.request().withPath("/ip"),
+            response = mock.response().withBody("127.0.0.1")
+        )
+
+        Fuel.get(mock.path("ip")).monoIgnored()
+            .test()
+            .assertNext { assertThat(it, equalTo(Unit)) }
+            .verifyComplete()
+    }
+
     private data class IpLong(val origin: Long)
 
     private object IpLongDeserializer : ResponseDeserializable<IpLong> {

--- a/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
+++ b/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
@@ -1,10 +1,14 @@
 package com.github.kittinunf.fuel.rx
 
-import com.github.kittinunf.fuel.core.*
+import com.github.kittinunf.fuel.core.Deserializable
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.deserializers.ByteArrayDeserializer
 import com.github.kittinunf.fuel.core.deserializers.EmptyDeserializer
 import com.github.kittinunf.fuel.core.deserializers.StringDeserializer
 import com.github.kittinunf.fuel.core.requests.CancellableRequest
+import com.github.kittinunf.fuel.core.response
 import com.github.kittinunf.result.Result
 import io.reactivex.Completable
 import io.reactivex.Single

--- a/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
+++ b/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
@@ -228,7 +228,7 @@ fun <T : Any> Request.rxObjectTriple(deserializable: Deserializable<T>) = rxResu
 /**
  * Returns a reactive stream for a [Single] value with only complete(success with [Unit]) or error signal
  */
-fun Request.rxIgnored(): Single<Unit> = rxResponseSingle(EmptyDeserializer)
+fun Request.rxUnit(): Single<Unit> = rxResponseSingle(EmptyDeserializer)
 
 /**
  * Generic [Single] wrapper that executes [resultBlock] and emits its result [R] to the [Single]

--- a/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
+++ b/fuel-rxjava/src/main/kotlin/com/github/kittinunf/fuel/rx/RxFuel.kt
@@ -6,6 +6,7 @@ import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.deserializers.ByteArrayDeserializer
+import com.github.kittinunf.fuel.core.deserializers.EmptyDeserializer
 import com.github.kittinunf.fuel.core.deserializers.StringDeserializer
 import com.github.kittinunf.fuel.core.requests.CancellableRequest
 import com.github.kittinunf.fuel.core.response
@@ -223,6 +224,11 @@ fun <T : Any> Request.rxObjectPair(deserializable: Deserializable<T>) = rxResult
  * @return [Single<Triple<Request, Response, Result<T, FuelError>>>] the [T] wrapped into a [Result] together with a [Triple] with [Response] and [Request]
  */
 fun <T : Any> Request.rxObjectTriple(deserializable: Deserializable<T>) = rxResultTriple(deserializable)
+
+/**
+ * Returns a reactive stream for a [Single] value with only complete(success with [Unit]) or error signal
+ */
+fun Request.rxIgnored(): Single<Unit> = rxResponseSingle(EmptyDeserializer)
 
 /**
  * Generic [Single] wrapper that executes [resultBlock] and emits its result [R] to the [Single]

--- a/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
+++ b/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
@@ -8,7 +8,7 @@ import com.github.kittinunf.fuel.core.ResponseDeserializable
 import com.github.kittinunf.fuel.rx.rxBytes
 import com.github.kittinunf.fuel.rx.rxBytesPair
 import com.github.kittinunf.fuel.rx.rxBytesTriple
-import com.github.kittinunf.fuel.rx.rxUnit
+import com.github.kittinunf.fuel.rx.rxCompletable
 import com.github.kittinunf.fuel.rx.rxObject
 import com.github.kittinunf.fuel.rx.rxResponse
 import com.github.kittinunf.fuel.rx.rxResponseObject
@@ -502,22 +502,17 @@ class RxFuelTest : MockHttpTestCase() {
     }
 
     @Test
-    fun rxUnit() {
+    fun rxCompletable() {
         mock.chain(
             request = mock.request().withPath("/user-agent"),
             response = mock.reflect()
         )
 
-        val data = Fuel.get(mock.path("user-agent"))
-            .rxUnit()
+       Fuel.get(mock.path("user-agent"))
+            .rxCompletable()
             .test()
             .apply { awaitTerminalEvent() }
             .assertNoErrors()
-            .assertValueCount(1)
             .assertComplete()
-            .values()[0]
-
-        assertThat(data, notNullValue())
-        assertThat(data, equalTo(Unit))
     }
 }

--- a/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
+++ b/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
@@ -8,7 +8,7 @@ import com.github.kittinunf.fuel.core.ResponseDeserializable
 import com.github.kittinunf.fuel.rx.rxBytes
 import com.github.kittinunf.fuel.rx.rxBytesPair
 import com.github.kittinunf.fuel.rx.rxBytesTriple
-import com.github.kittinunf.fuel.rx.rxIgnored
+import com.github.kittinunf.fuel.rx.rxUnit
 import com.github.kittinunf.fuel.rx.rxObject
 import com.github.kittinunf.fuel.rx.rxResponse
 import com.github.kittinunf.fuel.rx.rxResponseObject
@@ -509,7 +509,7 @@ class RxFuelTest : MockHttpTestCase() {
         )
 
         val data = Fuel.get(mock.path("user-agent"))
-            .rxIgnored()
+            .rxUnit()
             .test()
             .apply { awaitTerminalEvent() }
             .assertNoErrors()

--- a/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
+++ b/fuel-rxjava/src/test/kotlin/com/github/kittinunf/fuel/RxFuelTest.kt
@@ -8,6 +8,7 @@ import com.github.kittinunf.fuel.core.ResponseDeserializable
 import com.github.kittinunf.fuel.rx.rxBytes
 import com.github.kittinunf.fuel.rx.rxBytesPair
 import com.github.kittinunf.fuel.rx.rxBytesTriple
+import com.github.kittinunf.fuel.rx.rxIgnored
 import com.github.kittinunf.fuel.rx.rxObject
 import com.github.kittinunf.fuel.rx.rxResponse
 import com.github.kittinunf.fuel.rx.rxResponseObject
@@ -498,5 +499,25 @@ class RxFuelTest : MockHttpTestCase() {
         val (value, error) = data
         assertThat(value, notNullValue())
         assertThat(error, nullValue())
+    }
+
+    @Test
+    fun rxUnit() {
+        mock.chain(
+            request = mock.request().withPath("/user-agent"),
+            response = mock.reflect()
+        )
+
+        val data = Fuel.get(mock.path("user-agent"))
+            .rxIgnored()
+            .test()
+            .apply { awaitTerminalEvent() }
+            .assertNoErrors()
+            .assertValueCount(1)
+            .assertComplete()
+            .values()[0]
+
+        assertThat(data, notNullValue())
+        assertThat(data, equalTo(Unit))
     }
 }

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
@@ -190,7 +190,7 @@ fun <T : Any, U : Deserializable<T>> Request.response(deserializable: U): Respon
  *
  * @throws Exception if there is an internal library error, not related to Network
  */
-fun Request.responseIgnored(): ResponseResultOf<Unit> = response(EmptyDeserializer)
+fun Request.responseUnit(): ResponseResultOf<Unit> = response(EmptyDeserializer)
 
 private fun <T : Any, U : Deserializable<T>> Request.response(
     deserializable: U,
@@ -241,10 +241,10 @@ suspend fun <T : Any, U : Deserializable<T>> Request.await(deserializable: U): T
  * Use this method to avoid huge memory allocation when using [com.github.kittinunf.fuel.core.requests.download]
  * to a large file without using response result
  *
- * To run method in different coroutine context, use `com.github.kittinunf.fuel.coroutines.awaitIgnored` in `fuel-coroutines` module
+ * To run method in different coroutine context, use `com.github.kittinunf.fuel.coroutines.awaitUnit` in `fuel-coroutines` module
  */
 @Throws(FuelError::class)
-suspend fun Request.awaitIgnored(): Unit = await(EmptyDeserializer)
+suspend fun Request.awaitUnit(): Unit = await(EmptyDeserializer)
 
 /**
  * Await [T] or [FuelError]

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Deserializable.kt
@@ -1,6 +1,7 @@
 package com.github.kittinunf.fuel.core
 
 import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.deserializers.EmptyDeserializer
 import com.github.kittinunf.fuel.core.requests.CancellableRequest
 import com.github.kittinunf.fuel.core.requests.DefaultBody
 import com.github.kittinunf.fuel.core.requests.RequestTaskCallbacks
@@ -177,6 +178,20 @@ fun <T : Any, U : Deserializable<T>> Request.response(deserializable: U): Respon
         .getOrThrow()
 }
 
+/**
+ * Ignore the response result
+ *
+ * Use this method to avoid huge memory allocation when using [com.github.kittinunf.fuel.core.requests.download]
+ * to a large download and without using the result [ByteArray]
+ *
+ * @see [com.github.kittinunf.fuel.core.Request.response]
+ *
+ * @note not async, use the variations with a handler instead.
+ *
+ * @throws Exception if there is an internal library error, not related to Network
+ */
+fun Request.responseIgnored(): ResponseResultOf<Unit> = response(EmptyDeserializer)
+
 private fun <T : Any, U : Deserializable<T>> Request.response(
     deserializable: U,
     success: (Request, Response, T) -> Unit,
@@ -219,6 +234,17 @@ suspend fun <T : Any, U : Deserializable<T>> Request.await(deserializable: U): T
         .onFailure { throw FuelError.wrap(it, response) }
         .getOrThrow()
 }
+
+/**
+ * Await the task or throws [FuelError] in current coroutine context.
+ *
+ * Use this method to avoid huge memory allocation when using [com.github.kittinunf.fuel.core.requests.download]
+ * to a large file without using response result
+ *
+ * To run method in different coroutine context, use `com.github.kittinunf.fuel.coroutines.awaitIgnored` in `fuel-coroutines` module
+ */
+@Throws(FuelError::class)
+suspend fun Request.awaitIgnored(): Unit = await(EmptyDeserializer)
 
 /**
  * Await [T] or [FuelError]

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/deserializers/EmptyDeserializer.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/deserializers/EmptyDeserializer.kt
@@ -1,0 +1,8 @@
+package com.github.kittinunf.fuel.core.deserializers
+
+import com.github.kittinunf.fuel.core.Deserializable
+import com.github.kittinunf.fuel.core.Response
+
+object EmptyDeserializer : Deserializable<Unit> {
+    override fun deserialize(response: Response) = Unit
+}

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/requests/DownloadRequestTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/requests/DownloadRequestTest.kt
@@ -3,7 +3,7 @@ package com.github.kittinunf.fuel.core.requests
 import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.Method
 import com.github.kittinunf.fuel.core.ResponseResultOf
-import com.github.kittinunf.fuel.core.responseIgnored
+import com.github.kittinunf.fuel.core.responseUnit
 import com.github.kittinunf.fuel.test.MockHttpTestCase
 import com.google.common.net.MediaType
 import org.hamcrest.CoreMatchers.equalTo
@@ -230,7 +230,7 @@ class DownloadRequestTest : MockHttpTestCase() {
     }
 
     @Test
-    fun awaitDownloadBigFileIgnored() {
+    fun downloadBigFileResponseUnit() {
         val manager = FuelManager()
 
         val numberOfBytes = 1024 * 1024 * 10 // 10 MB
@@ -248,7 +248,7 @@ class DownloadRequestTest : MockHttpTestCase() {
         val triple = manager.download(mock.path("bytes"))
             .fileDestination { _, _ -> file }
             .progress { readBytes, totalBytes -> read = readBytes; total = totalBytes }
-            .responseIgnored()
+            .responseUnit()
 
         assertDownloadedBytesToFile(triple, file, numberOfBytes)
         assertThat("Progress read bytes and total bytes should be equal",


### PR DESCRIPTION
## Description

Recently I used `Request.download()` and `Request.awaitString()` functions to download a large file. However `awaitString()` function threw an exception about memory allocation too large.

Existing functions like `Request.responseString()`, `Request.response()`, `Request.await(Deserializable)` which used either `ByteArrayDeserializer` or `StringDeserializer` will deserialize result then may cause the same problem.

Then I noticed the  [document](https://fuel.gitbook.io/documentation/core/fuel#download-response-to-output-file-or-outputstream) metioned an `EmptyDeserializer` can be used to both download the file and avoid getting result. But `EmptyDeserializer` was not found in library.

This PR added a `EmptyDeserializer` and some extension functions(in core, coroutine, reactor, rx modules) named `***Ignored()`. They can be used with `download()` or somewhere users don't want to retrieve the response result.

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added corresponding unit tests and had them passed.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
