### PR TITLE
setFixedLengthStreamingMode Fix for API < 19

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -241,7 +241,11 @@ class HttpClient(
         val contentLength = body.length
         if (contentLength != null && contentLength != -1L) {
             // The content has a known length, so no need to chunk
-            connection.setFixedLengthStreamingMode(contentLength.toLong())
+            try {
+                connection.setFixedLengthStreamingMode(contentLength.toLong())
+            } catch (e: NoSuchMethodError) {
+                connection.setFixedLengthStreamingMode(contentLength.toInt())
+            }
         } else {
             // The content doesn't have a known length, so turn it into chunked
             connection.setChunkedStreamingMode(4096)


### PR DESCRIPTION
## Description

setFixedLengthStreamingMode(Long) requires at least Android API 19. If that method is not found, call the old setFixedLengthStreamingMode(Int).

## Type of change

Check all that apply

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested this with my app and API 15.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
