### PR TITLE
fix: Add test assets to the inputs of task "test"

### DIFF
--- a/fuel/build.gradle.kts
+++ b/fuel/build.gradle.kts
@@ -4,3 +4,7 @@ dependencies {
     testImplementation(project(Fuel.Test.name))
     testImplementation(Json.dependency)
 }
+
+tasks.getByName("test") {
+    inputs.dir("src/test/assets")
+}


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

This commit enhances the incremental task "test".
Notable, this task uses the files included in the directory `src/test/assets/`.
Some tests depend on them (i.e., there are assertions that depend on the state of these files). So, any update to any of those files should re-trigger the task "test".

This pull request adds those files as input to this task.

## Type of change

- [X] Bug fix (a non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
