### PR TITLE
:memo: Update README.md with jcenter repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ You can [download](https://bintray.com/kittinunf/maven/Fuel-Android/_latestVersi
   implementation 'com.github.kittinunf.fuel:<package>:<latest-version>'
 ```
 
+Make sure to include `jcenter()` in your repositories 
+```groovy
+repositories {
+  jcenter()
+}
+```
+
 Each of the extensions / integrations has to be installed separately.
 
 | Package | Description |


### PR DESCRIPTION
I've spent quite time figuring out why gradle was failing to build dependencies. Maybe this note can help someone.

