### PR TITLE
[#662] Add method to provide object as a body content

### DIFF
--- a/fuel-jackson/README.md
+++ b/fuel-jackson/README.md
@@ -15,8 +15,47 @@ implementation 'com.github.kittinunf.fuel:fuel-jackson:<latest-version>'
 
 ## Usage
 
-The Fuel-Jackson module provides a built in support for Jackson deserialization.
-This is done by adding the `responseObject` extension function into Fuel `Request` interface.
+The Fuel-Jackson module provides a built in support for Jackson serialization and deserialization.
+
+### Serialization
+
+The serialization is done by adding the `objectBody` extension function into Fuel `Request` interface.
+
+By default, the `objectBody` call will use the `Charsets.UTF-8` charset and the `defaultMapper` property defined in `FuelJackson.kt`.
+
+```kotlin
+data class FakeObject(val foo: String = "foo")
+
+Fuel.post("/fooBar")
+    .objectBody(FakeObject())
+```
+
+Alternatively, you can provide a custom `charset` as a parameter to it.
+
+```kotlin
+data class FakeObject(val foo: String = "foo")
+
+Fuel.post("/fooBar")
+    .objectBody(FakeObject(), Charsets.UTF_16)
+```
+
+You can also provide your own `ObjectMapper` as a parameter.
+
+```kotlin
+data class FakeObject(val foo: String = "foo")
+
+val mapper = ObjectMapper().registerKotlinModule()
+                           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+mapper.propertyNamingStrategy = PropertyNamingStrategy.SNAKE_CASE
+
+Fuel.post("/fooBar")
+    .objectBody(FakeObject(), mapper = mapper)
+```
+
+### Deserialization
+
+The deserialization is done by adding the `responseObject` extension function into Fuel `Request` interface.
 
 By default, the `responseObject` call will use the `defaultMapper` property defined in `FuelJackson.kt`.
 

--- a/fuel-jackson/src/main/kotlin/com/github/kittinunf/fuel/jackson/ObjectBody.kt
+++ b/fuel-jackson/src/main/kotlin/com/github/kittinunf/fuel/jackson/ObjectBody.kt
@@ -1,0 +1,19 @@
+package com.github.kittinunf.fuel.jackson
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.kittinunf.fuel.core.Headers
+import com.github.kittinunf.fuel.core.Request
+import java.nio.charset.Charset
+
+/**
+ * Set the body to an Object to be serialized
+ */
+fun Request.objectBody(
+    bodyObject: Any,
+    charset: Charset = Charsets.UTF_8,
+    mapper: ObjectMapper = defaultMapper
+): Request {
+    val bodyString = mapper.writeValueAsString(bodyObject)
+    this[Headers.CONTENT_TYPE] = "application/json"
+    return body(bodyString, charset)
+}

--- a/fuel-jackson/src/test/kotlin/com/github/kittinunf/fuel/ObjectBodyTest.kt
+++ b/fuel-jackson/src/test/kotlin/com/github/kittinunf/fuel/ObjectBodyTest.kt
@@ -1,0 +1,67 @@
+package com.github.kittinunf.fuel
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.github.kittinunf.fuel.core.Headers
+import com.github.kittinunf.fuel.core.Method
+import com.github.kittinunf.fuel.core.requests.DefaultRequest
+import com.github.kittinunf.fuel.jackson.objectBody
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import java.net.URL
+
+class ObjectBodyTest {
+    @Test
+    fun setsBodyCorrectly() {
+        val expectedBody = "{\"foo\":42,\"bar\":\"foo bar\",\"fooBar\":\"foo bar\"}"
+        val bodyObject = FakeObject()
+
+        val request = DefaultRequest(Method.POST, URL("https://test.fuel.com/body"))
+            .objectBody(bodyObject)
+
+        assertThat(expectedBody, equalTo(String(request.body.toByteArray())))
+    }
+
+    @Test
+    fun setsContentTypeCorrectly() {
+        val bodyObject = listOf(
+            42,
+            mapOf("foo" to "bar")
+        )
+
+        val request = DefaultRequest(Method.POST, URL("https://test.fuel.com/body"))
+            .objectBody(bodyObject)
+
+        assertThat(request[Headers.CONTENT_TYPE].lastOrNull(), equalTo("application/json"))
+    }
+
+    @Test
+    fun setsBodyCorrectlyWithCustomMapper() {
+        val mapper = createCustomMapper()
+        val expectedBody = "{\"foo\":42,\"bar\":\"foo bar\",\"foo_bar\":\"foo bar\"}"
+        val bodyObject = FakeObject()
+
+        val request = DefaultRequest(Method.POST, URL("https://test.fuel.com/body"))
+            .objectBody(bodyObject, mapper = mapper)
+
+        assertThat(expectedBody, equalTo(String(request.body.toByteArray())))
+    }
+
+    private fun createCustomMapper(): ObjectMapper {
+        val mapper = ObjectMapper().registerKotlinModule()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+        mapper.propertyNamingStrategy = PropertyNamingStrategy.SNAKE_CASE
+
+        return mapper
+    }
+}
+
+data class FakeObject(
+    val foo: Int = 42,
+    val bar: String = "foo bar",
+    val fooBar: String = "foo bar"
+)


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description

<!-- Include a summary of the change and which [issue](https://github.com/kittinunf/Fuel/issues)
this fixes. Also, include relevant motivation and context. List any dependencies
that are required for this change and why they are necessary. -->

This Pull-request aims to add a method to allow providing an object as a body content, using Jackson's serialization.

This also closes #662.

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [x] This change requires a documentation update

## How Has This Been Tested?

Unit tests were added at `ObjectBodyTest.kt`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
