### PR TITLE
RxJava 2.2.19

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -158,7 +158,7 @@ object Reactor {
 
 object RxJava {
     object Jvm {
-        const val version = "2.2.8"
+        const val version = "2.2.19"
         const val dependency = "io.reactivex.rxjava2:rxjava:$version"
     }
 


### PR DESCRIPTION
## Description

- Update RxJava version from 2.2.8 to 2.2.19
  - 2.2.19 is a bugfix version of the latest 2.x releases under maintenance mode.
  - It  update to this before migrating to 3.x.
  - Diff: https://github.com/ReactiveX/RxJava/compare/v2.2.8...v2.2.19

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)
  Involving bugfixes under the hood of RxJava

## How Has This Been Tested?

Tested `fuel-rxjava` with unit tests.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes