### PR TITLE
Update Target and Compile SDK Version to 29

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -196,7 +196,7 @@ object Jacoco {
 }
 
 object RoboElectric {
-    const val version = "4.2.1"
+    const val version = "4.3.1"
     const val dependency = "org.robolectric:robolectric:$version"
 }
 

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -3,7 +3,7 @@ object Fuel {
     const val publishVersion = "2.2.1"
     const val groupId = "com.github.kittinunf.fuel"
 
-    const val compileSdkVersion = 28
+    const val compileSdkVersion = 29
     const val minSdkVersion = 19
 
     const val name = ":fuel"


### PR DESCRIPTION
## Description

- Now the target and compile sdk version is 29, which is Android 10.
  - The next Android R is coming within a few months and it is required to keep target sdk version 1 version behind the latest Android.
  - Robolectric now supports Android 10 in 4.3.1 so it is also updated in this change.

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes