### PR TITLE
:memo: Documentation: Add Snippets for Maven and Gradle

### DIFF
--- a/fuel-coroutines/README.md
+++ b/fuel-coroutines/README.md
@@ -7,9 +7,28 @@ You can [download](https://bintray.com/kittinunf/maven/Fuel-Android/_latestVersi
 * [`Fuel`](../fuel/README.md)
 * KotlinX Coroutines: 1.1.1
 
+### Gradle
+
 ```groovy
 implementation 'com.github.kittinunf.fuel:fuel:<latest-version>'
 implementation 'com.github.kittinunf.fuel:fuel-coroutines:<latest-version>'
+```
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>com.github.kittinunf.fuel</groupId>
+    <artifactId>fuel</artifactId>
+    <version>[LATEST_VERSION]</version>
+</dependency>
+
+<dependency>
+    <groupId>com.github.kittinunf.fuel</groupId>
+    <artifactId>fuel-coroutines</artifactId>
+    <version>[LATEST_VERSION]</version>
+</dependency>
+
 ```
 
 ## Usage


### PR DESCRIPTION
## Description

Documentation: I thought it was confusing that the the fuel coroutines 'download' link was pointing to the Android package. This change adds Snippets for installing with Maven and Gradle package managers.