### PR TITLE
:bug: Fix Transfer-Encoding field value to be case-insensitive

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/DecodeStream.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/util/DecodeStream.kt
@@ -17,7 +17,7 @@ private val UNSUPPORTED_DECODE_ENCODING: DecodeFallbackCallback = { _, encoding 
  * @return [InputStream] the wrapped [InputStream] that is decoded when it's being read
  */
 fun InputStream.decode(encoding: String, unsupported: DecodeFallbackCallback = UNSUPPORTED_DECODE_ENCODING) =
-    when (encoding.trim()) {
+    when (encoding.trim().toLowerCase()) {
         "gzip" -> GZIPInputStream(this)
         "deflate" -> InflaterInputStream(this)
         // HTTPClient handles chunked, but does not remove the Transfer-Encoding Header


### PR DESCRIPTION
<!-- Thank you for submitting your Pull Request. Please make sure you have
familiarised yourself with the [Contributing Guidelines](https://github.com/kittinunf/Fuel/CONTRIBUTING.md)
before continuing. -->

<!-- Remove anything that doesn't apply -->

## Description
 Fix Transfer-Encoding field value to be case-insensitive, in accordance with RFC-7230.

RFC-7230, section 4 states the following:
"All transfer-coding names are case-insensitive[...]"

Fix kittinunf#743
<!-- Include a summary of the change and which [issue](https://github.com/kittinunf/Fuel/issues)
this fixes. Also, include relevant motivation and context. List any dependencies
that are required for this change and why they are necessary. -->

<!-- Fixes #0
Fixes #0 -->

## Type of change
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have made a GET request to a server that responds with `"Chunked"` for the Transfer-Encoding field value, and saw that the response was decoded successfully. Also, made sure that old tests still pass.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
