### PR TITLE
:bug: Charset issue fix (#718)

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/BodyRepresentation.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/BodyRepresentation.kt
@@ -19,7 +19,7 @@ fun Body.representationOfBytes(contentType: String?): String {
         var charset = Charsets.UTF_8
         val charsetGroup = TEXT_CONTENT_TYPE.find(actualContentType)!!.groupValues[1]
         if (charsetGroup.isNotEmpty()) {
-            val charsetName = charsetGroup.substringAfter('=').toUpperCase()
+            val charsetName = charsetGroup.substringAfter('=').substringBefore(';').toUpperCase()
             charset = Charset.forName(charsetName)
         }
         return String(toByteArray(), charset)

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/BodyRepresentationTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/BodyRepresentationTest.kt
@@ -167,6 +167,26 @@ class BodyRepresentationTest : MockHttpTestCase() {
     }
 
     @Test
+    fun textRepresentationOfJsonWithUtf8AndOtherParameters() {
+        val contentTypes = listOf(
+                "application/json;charset=utf-8;api-version=5.1",
+                "application/json; charset=utf-8; api-version=5.1",
+                "application/json;charset=utf-8;api-version=5.1;test=true",
+                "application/json; charset=utf-8; api-version=5.1; test=true"
+        )
+        val content = "{ \"foo\": 42 }"
+
+        contentTypes.forEach { contentType ->
+            assertThat(
+                    DefaultBody
+                            .from({ ByteArrayInputStream(content.toByteArray()) }, { content.length.toLong() })
+                            .asString(contentType),
+                    equalTo(content)
+            )
+        }
+    }
+
+    @Test
     fun textRepresentationOfCsv() {
         val contentTypes = listOf("text/csv")
         val content = "function test()"


### PR DESCRIPTION
## Description

Added `substringBefore(';')` to exclude any parameters after the charset one. Previously, if there were any parameters after "charset", they ended up in the `charsetName` variable and caused an exception on `Charset.forName(charsetName)` function call.

Fixed #718 

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested by creating extension functions `Body.representationOfBytesX()`, `Body.asStringX()` and `Response.toStringX()` and using them in a couple of projects. The functions itself were just a copy of the corresponding functions with small changes:
- For `Body.representationOfBytesX()` the change was the same as in the commit - added `substringBefore(';')`
- For `asStringX()` and `toStringX()` the only change was replacement the common functions with the extension ones created by me (mentioned before).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
