### PR TITLE
Fix content-length header not being sent when messages have empty body

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/HttpClient.kt
@@ -234,7 +234,11 @@ class HttpClient(
 
     private fun setBodyIfDoOutput(connection: HttpURLConnection, request: Request) {
         val body = request.body
-        if (!connection.doOutput || body.isEmpty()) {
+        if (!connection.doOutput) {
+            return
+        }
+        if (body.isEmpty()) {
+            connection.setFixedLengthStreamingMode(0L)
             return
         }
 

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/toolbox/HttpClientTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/toolbox/HttpClientTest.kt
@@ -56,7 +56,19 @@ class HttpClientTest : MockHttpTestCase() {
     }
 
     @Test
-    fun setsContentLengthIfKnown() {
+    fun setsContentLengthIfKnownZero() {
+        val request = reflectedRequest(Method.POST, "content-length-test")
+                .body("")
+
+        val (_, _, result) = request.responseObject(MockReflected.Deserializer())
+        val (data, error) = result
+
+        assertThat("Expected data, actual error $error", data, notNullValue())
+        assertThat(data!![Headers.CONTENT_LENGTH].firstOrNull(), equalTo("0"))
+    }
+
+    @Test
+    fun setsContentLengthIfKnownNonZero() {
         val request = reflectedRequest(Method.POST, "content-length-test")
             .body("my-body")
 


### PR DESCRIPTION
## Description

It happened because streaming mode was used in these cases. See #748 The fix can be seen as a fast path: It would probably not be required to have the `isEmpty()` check in the first place for correctness alone.

Fixes #748

## Type of change

Check all that apply

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually, and a unit/regression test was added.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
