### PR TITLE
Fix Jackson extension functions and their tests

### DIFF
--- a/fuel-jackson/src/main/kotlin/com/github/kittinunf/fuel/jackson/FuelJackson.kt
+++ b/fuel-jackson/src/main/kotlin/com/github/kittinunf/fuel/jackson/FuelJackson.kt
@@ -17,13 +17,11 @@ import java.io.Reader
 val defaultMapper = ObjectMapper().registerKotlinModule()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
-inline fun <reified T : Any> Request.responseObject(noinline handler: (Request, Response, Result<T, FuelError>) -> Unit) {
-    response(jacksonDeserializerOf(), handler)
-}
+inline fun <reified T : Any> Request.responseObject(noinline handler: (Request, Response, Result<T, FuelError>) -> Unit) =
+        response(jacksonDeserializerOf(), handler)
 
-inline fun <reified T : Any> Request.responseObject(mapper: ObjectMapper, noinline handler: (Request, Response, Result<T, FuelError>) -> Unit) {
-    response(jacksonDeserializerOf(mapper), handler)
-}
+inline fun <reified T : Any> Request.responseObject(mapper: ObjectMapper, noinline handler: (Request, Response, Result<T, FuelError>) -> Unit) =
+        response(jacksonDeserializerOf(mapper), handler)
 
 inline fun <reified T : Any> Request.responseObject(mapper: ObjectMapper, handler: ResponseHandler<T>) = response(jacksonDeserializerOf(mapper), handler)
 


### PR DESCRIPTION
This fixes the tests of Jackson extension functions for asynchronous requests (#776). These tests were silently failing for a long time because of the assertions in the callbacks which are async and not visible to the test engine. As a result, the tests became out of date, so aside from ensuring the assertions are now able to fail the tests this PR also contains a decent amount of changes in the setup procedures as well as assertions themselves.

Assertions are now ensured to take an effect on the test outcome by explicitly awaiting on the `CancellableRequest` object which is returned by the extension functions using the `get()` method inherited from `Future<Response>`.
This change also fixes two extension functions that did not return `CancellableRequest` object for no reason (#775).

I also fixed code formatting around the lines I touched according to what seems to be the most common in this project.

Fixes #775 and #776.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I did not include any new tests for the change in the production code (#775) 
because existing tests do verify that change after the fix of #776.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas **(n/a)**
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why **(n/a)**
