### PR TITLE
Fix: PATCH on HTTPS endpoint

### DIFF
--- a/fuel-test/src/main/kotlin/com/github/kittinunf/fuel/test/MockHelper.kt
+++ b/fuel-test/src/main/kotlin/com/github/kittinunf/fuel/test/MockHelper.kt
@@ -137,6 +137,8 @@ class MockHelper {
      */
     fun path(path: String): String = URL("http://localhost:${server().localPort}/$path").toString()
 
+    fun securedPath(path: String): String = URL("https://localhost:${server().localPort}/$path").toString()
+
     companion object {
         const val REFLECT_TEMPLATE = """
             return {

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/extensions/ForceMethod.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/toolbox/extensions/ForceMethod.kt
@@ -20,16 +20,20 @@ fun HttpURLConnection.forceMethod(method: Method) {
             } catch (ex: NoSuchFieldException) {
                 // ignore
             }
-            (arrayOf(this.javaClass.superclass, this.javaClass)).forEach {
-                try {
-                    it.getDeclaredField("method").apply {
-                        this.isAccessible = true
-                    }.set(this, method.value)
-                } catch (ex: NoSuchFieldException) {
-                    // ignore
-                }
-            }
+            this.forceMethod(this.javaClass, method)
         }
         else -> this.requestMethod = method.value
+    }
+}
+
+private fun HttpURLConnection.forceMethod(clazz: Class<in HttpURLConnection>, method: Method) {
+    try {
+        clazz.getDeclaredField("method").apply {
+            this.isAccessible = true
+        }.set(this, method.value)
+    } catch (ex: NoSuchFieldException) {
+        if (HttpURLConnection::class.java.isAssignableFrom(clazz.superclass)) {
+            this.forceMethod(clazz.superclass, method)
+        }
     }
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/toolbox/extensions/ForceMethodTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/toolbox/extensions/ForceMethodTest.kt
@@ -26,4 +26,22 @@ class ForceMethodTest : MockHttpTestCase() {
         httpUrlConnection.forceMethod(Method.POST)
         assertThat(httpUrlConnection.requestMethod, equalTo(Method.POST.value))
     }
+
+    @Test
+    fun forceHttpsPatchMethod() {
+        val connection = URL(this.mock.securedPath("secured-force-patch-test")).openConnection()
+        assert(connection is HttpURLConnection)
+        val httpUrlConnection = connection as HttpURLConnection
+        httpUrlConnection.forceMethod(Method.PATCH)
+        assertThat(httpUrlConnection.requestMethod, equalTo(Method.PATCH.value))
+    }
+
+    @Test
+    fun forceHttpsPostMethod() {
+        val connection = URL(this.mock.securedPath("secured-force-post-test")).openConnection()
+        assert(connection is HttpURLConnection)
+        val httpUrlConnection = connection as HttpURLConnection
+        httpUrlConnection.forceMethod(Method.POST)
+        assertThat(httpUrlConnection.requestMethod, equalTo(Method.POST.value))
+    }
 }


### PR DESCRIPTION
## Description
The `forceMethod` extension used to set the correct HTTP method when using PATCH uses reflexion to force the value of the `method` field in the `HttpURLConnection` class.

In the case of HTTPS, the class hierarchy of the connection class is more complex, and the `forceMethod` extension doesn't go back enough in the parent classes to find the correct `method` field to set.

This PR fixes the `forceMethod` extension.

Fixes #784 

## Type of change

- [X] Bug fix (a non-breaking change which fixes an issue)

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

