### PR TITLE
Add Path Fixing on Codecov

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -14,3 +14,5 @@ jobs:
         arguments: check jacocoTestReport
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
+      with:
+       functionalities: fix


### PR DESCRIPTION
## Description

it seems Github Actions add more path on root, so codecov couldn't compare with the git structures.

## Type of change

Check all that apply

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update
