### PR TITLE
Fix to use UTF-8 instead of US_ASCII

### DIFF
--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/BodyRepresentation.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/BodyRepresentation.kt
@@ -26,7 +26,7 @@ fun Body.representationOfBytes(contentType: String?): String {
         val charset: Charset = try {
             Charset.forName(parameters.find { charsetRegex.matches(it) }?.substringAfter("CHARSET=") ?: "")
         } catch (e: IllegalCharsetNameException) {
-            Charsets.US_ASCII
+            Charsets.UTF-8
         }
 
         return String(toByteArray(), charset)

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/BodyRepresentationTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/BodyRepresentationTest.kt
@@ -152,6 +152,21 @@ class BodyRepresentationTest : MockHttpTestCase() {
     }
 
     @Test
+    fun textRepresentationOfJsonWithMultibyteCharacterSets() {
+        val contentTypes = listOf("application/json")
+        val content = "{ \"foo\": \"４２\" }"
+
+        contentTypes.forEach { contentType ->
+            assertThat(
+                DefaultBody
+                    .from({ ByteArrayInputStream(content.toByteArray()) }, { content.length.toLong() })
+                    .asString(),
+                equalTo(content)
+            )
+        }
+    }
+
+    @Test
     fun textRepresentationOfJsonWithUtf8Charset() {
         val contentTypes = listOf("application/json;charset=utf-8", "application/json; charset=utf-8")
         val content = "{ \"foo\": 42 }"


### PR DESCRIPTION
## Description

Fix to use `Charsets.UTF-8` instead of `Charsets.US_ASCII`.
If there is no charset in the Content-Type header value, `Charsets.US_ASCII` is used and the multibyte character sets is garbled.
https://github.com/kittinunf/fuel/blob/823df71af8d9d70ed477d5d22eb0548045b95fad/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/BodyRepresentation.kt#L29

I think it would be better to use `Charsets.UTF-8`. because the documentation says:
> https://fuel.gitbook.io/documentation/core/fuel#blocking-responses
> The default charset is UTF-8.

Fixes #815

## Type of change
Check all that apply

* [x]  Bug fix (a non-breaking change which fixes an issue)
* [ ]  New feature (a non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  Refactoring (a change which changes the current internal or external interface)
* [ ]  This change requires a documentation update

## How Has This Been Tested?

I added a test case with multibyte character sets.

## Checklist:
* [x]  I have performed a self-review of my own code
* [ ]  I have commented my code, particularly in hard-to-understand areas
* [ ]  I have made corresponding changes to the documentation, if necessary
* [ ]  My changes generate no new compiler warnings
* [x]  I have added tests that prove my fix is effective or that my feature works
* [ ]  New and existing unit tests pass locally with my changes
* [ ]  Inspect the bytecode viewer, including reasoning why