### PR TITLE
📝 jcenter() is at end-of-life, recommend mavenCentral() instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Fuel
 
-[![jcenter](https://api.bintray.com/packages/kittinunf/maven/Fuel-Android/images/download.svg)](https://bintray.com/kittinunf/maven/Fuel-Android/_latestVersion)
 [![mavenCentral](https://maven-badges.herokuapp.com/maven-central/com.github.kittinunf.fuel/fuel/badge.svg)](https://search.maven.org/search?q=g:com.github.kittinunf.fuel)
 [![Build Status](https://travis-ci.org/kittinunf/fuel.svg?branch=master)](https://travis-ci.org/kittinunf/fuel)
 [![Codecov](https://codecov.io/github/kittinunf/fuel/coverage.svg?branch=master)](https://codecov.io/gh/kittinunf/fuel)
@@ -38,10 +37,10 @@ You can [download](https://bintray.com/kittinunf/maven/Fuel-Android/_latestVersi
   implementation 'com.github.kittinunf.fuel:<package>:<latest-version>'
 ```
 
-Make sure to include `jcenter()` or `mavenCentral()` in your repositories 
+Make sure to include or `mavenCentral()` in your repositories (`jcenter()` is deprecated, new releases starting from 2.2.3 are hosted on `mavenCentral()`)
 ```groovy
 repositories {
-  jcenter() //or mavenCentral()
+  mavenCentral()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can [download](https://bintray.com/kittinunf/maven/Fuel-Android/_latestVersi
   implementation 'com.github.kittinunf.fuel:<package>:<latest-version>'
 ```
 
-Make sure to include or `mavenCentral()` in your repositories (`jcenter()` is deprecated, new releases starting from 2.2.3 are hosted on `mavenCentral()`)
+Make sure to include `mavenCentral()` in your repositories (`jcenter()` is deprecated, new releases starting from 2.2.3 are hosted on `mavenCentral()`)
 ```groovy
 repositories {
   mavenCentral()


### PR DESCRIPTION
JCenter is at end-of-life and will be made read only on March 31st, 2021. To prevent developers from inserting a `jcenter()` declaration in their `build.gradle`, I changed the code snippet in the documentation to `mavenCentral()`. MC seems to host artifacts for >=3.2.2 and JC for <3.2.2. I also removed the JC icon at the beginning as it was not working anyway.

For more information, check this StackOverflow question: https://stackoverflow.com/questions/66400264/jcenter-is-at-end-of-life-android-lint-warning-what-is-the-replacement

I am new to this project so I hope I was useful.