### PR TITLE
Add support for IDNA 2008 (RFC 5891) when encoding URL (#819)

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -238,3 +238,8 @@ object Stetho {
         const val dependency = "com.facebook.stetho:stetho-urlconnection:$version"
     }
 }
+
+object ICU {
+    const val version = "70.1"
+    const val dependency = "com.ibm.icu:icu4j:$version"
+}

--- a/fuel/build.gradle.kts
+++ b/fuel/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
     api(Result.dependency)
+    implementation(ICU.dependency)
 
     testImplementation(project(Fuel.Test.name))
     testImplementation(Json.dependency)

--- a/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
+++ b/fuel/src/main/kotlin/com/github/kittinunf/fuel/core/Encoding.kt
@@ -1,9 +1,9 @@
 package com.github.kittinunf.fuel.core
 
 import com.github.kittinunf.fuel.core.requests.DefaultRequest
+import com.ibm.icu.text.IDNA
 import java.net.MalformedURLException
 import java.net.URI
-import java.net.URISyntaxException
 import java.net.URL
 
 class Encoding(
@@ -12,6 +12,8 @@ class Encoding(
     val baseUrlString: String? = null,
     val parameters: Parameters? = null
 ) : RequestFactory.RequestConvertible {
+
+    private val idna: IDNA = IDNA.getUTS46Instance(flags)
 
     private val encoder: (Method, String, Parameters?) -> Request = { method, path, parameters ->
         DefaultRequest(
@@ -36,13 +38,35 @@ class Encoding(
             }
             URL(base + if (path.startsWith('/') or path.isEmpty()) path else "/$path")
         }
-        val uri = try {
-            url.toURI()
-        } catch (e: URISyntaxException) {
-            URI(url.protocol, url.userInfo, url.host, url.port, url.path, url.query, url.ref)
-        }
+
+        val uri = URI(
+            url.protocol,
+            url.userInfo,
+            // converts domain to A-Label (RFC 5891)
+            domainToAscii(url.host),
+            url.port,
+            url.path,
+            url.query,
+            url.ref
+        )
+
         return URL(uri.toASCIIString())
     }
 
+    private fun domainToAscii(domain: String): String {
+        val info = IDNA.Info()
+        val sb = StringBuilder()
+        val domainAscii = idna.nameToASCII(domain, sb, info).toString()
+        if (info.hasErrors()) {
+            throw MalformedURLException(info.errors.toString())
+        }
+        return domainAscii
+    }
+
     private val defaultHeaders = Headers.from()
+
+    companion object {
+        private const val flags =
+            IDNA.CHECK_BIDI or IDNA.CHECK_CONTEXTJ or IDNA.CHECK_CONTEXTO or IDNA.NONTRANSITIONAL_TO_ASCII or IDNA.USE_STD3_RULES
+    }
 }

--- a/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/EncodingTest.kt
+++ b/fuel/src/test/kotlin/com/github/kittinunf/fuel/core/EncodingTest.kt
@@ -1,0 +1,72 @@
+package com.github.kittinunf.fuel.core
+
+import java.net.MalformedURLException
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Enclosed::class)
+internal class EncodingTest {
+
+    @RunWith(Parameterized::class)
+    internal class Valid(
+        private val inputUrl: String,
+        private val encodedUrl: String
+    ) {
+
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters(name = "validUrl")
+            fun data() = listOf(
+                arrayOf("https://github.com/kittinunf/fuel/", "https://github.com/kittinunf/fuel/"),
+                arrayOf(
+                    "https://xn----f38am99bqvcd5liy1cxsg.test",
+                    "https://xn----f38am99bqvcd5liy1cxsg.test"
+                ),
+                arrayOf("https://test.xn--rhqv96g", "https://test.xn--rhqv96g"),
+                arrayOf("https://test.شبك", "https://test.xn--ngbx0c"),
+                arrayOf("https://普遍接受-测试.top", "https://xn----f38am99bqvcd5liy1cxsg.top"),
+                arrayOf(
+                    "https://मेल.डाटामेल.भारत",
+                    "https://xn--r2bi6d.xn--c2bd4bq1db8d.xn--h2brj9c"
+                ),
+                arrayOf("http://fußball.de", "http://xn--fuball-cta.de"),
+                arrayOf("http://fußball.de", "http://xn--fuball-cta.de"),
+            )
+        }
+
+        @Test
+        fun testRequestURLIDNAEncoding() {
+            val encoding = Encoding(
+                httpMethod = Method.GET,
+                urlString = inputUrl,
+            )
+            assertThat(encoding.request.url.toString(), equalTo(encodedUrl))
+        }
+    }
+
+
+    @RunWith(Parameterized::class)
+    internal class Invalid(
+        private val inputUrl: String
+    ) {
+
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters(name = "invalidUrl")
+            fun data() = listOf(
+                "https://in--valid",
+                "https://.test.top",
+                "https://\\u0557w.test"
+            )
+        }
+
+        @Test(expected = MalformedURLException::class)
+        fun testRequestInvalidURL() {
+            Encoding(httpMethod = Method.GET, urlString = inputUrl).request
+        }
+    }
+}


### PR DESCRIPTION
## Description

Convert URL host to A-Label before making a request.
`IDNA` object is provided by ICU4j dependency for JVM but on Android it is included in `android.icu.text.IDNA` so you may want to handle it differently for Android which I did not do.

Fixes #819 

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (a change which changes the current internal or external interface)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Inspect the bytecode viewer, including reasoning why
