### PR TITLE
[3.x] Update deps version and remove warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ use the `any http method` [suspend](https://kotlinlang.org/docs/reference/corout
 
 ```kotlin
 runBlocking {
-    val string = Fuel.get("https://publicobject.com/helloworld.txt").body!!.string()
+    val string = Fuel.get("https://httpbin.org/get").body.string()
     println(string)
 }
 
 runBlocking {
-    val string = "https://publicobject.com/helloworld.txt".httpGet().body!!.string()
+    val string = "https://httpbin.org/get".httpGet().body.string()
     println(string)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.5.0"
-    kotlin("kapt") version "1.5.0" apply false
+    kotlin("jvm") version "1.7.21"
+    kotlin("kapt") version "1.7.21" apply false
     id("com.vanniktech.maven.publish") version "0.10.0" apply false
     jacoco
 }
@@ -13,8 +13,8 @@ allprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "jacoco")
 
-    val okhttpVersion by extra("5.0.0-alpha.2")
-    val moshiVersion by extra("1.12.0")
+    val okhttpVersion by extra("5.0.0-alpha.10")
+    val moshiVersion by extra("1.14.0")
 
     repositories {
         mavenCentral()

--- a/fuel-async/fuel-coroutines/src/test/kotlin/fuel/CoroutinesTest.kt
+++ b/fuel-async/fuel-coroutines/src/test/kotlin/fuel/CoroutinesTest.kt
@@ -33,7 +33,7 @@ internal class CoroutinesTest {
 
         val request = Request.Builder().data(mockWebServer.url("url")).build()
         val response = HttpLoader().get(request).toCoroutines()
-        assertEquals("Hello Get", response.body!!.string())
+        assertEquals("Hello Get", response.body.string())
     }
 
     @Test

--- a/fuel-async/fuel-reactor/src/test/kotlin/fuel/ReactorTest.kt
+++ b/fuel-async/fuel-reactor/src/test/kotlin/fuel/ReactorTest.kt
@@ -33,7 +33,7 @@ internal class ReactorTest {
             .toMono()
             .test()
             .assertNext {
-                assertEquals("Hello Get", it.body!!.string())
+                assertEquals("Hello Get", it.body.string())
             }
             .thenCancel()
             .verify()

--- a/fuel-async/fuel-rx3/build.gradle.kts
+++ b/fuel-async/fuel-rx3/build.gradle.kts
@@ -4,7 +4,7 @@ val okhttpVersion: String by extra
 
 dependencies {
     api(project(":fuel-base"))
-    api("io.reactivex.rxjava3:rxjava:3.0.11")
+    api("io.reactivex.rxjava3:rxjava:3.1.5")
 
     testImplementation("junit:junit:4.13")
     testImplementation("com.squareup.okhttp3:mockwebserver:$okhttpVersion")

--- a/fuel-base/src/test/kotlin/fuel/HttpLoaderBuilderTest.kt
+++ b/fuel-base/src/test/kotlin/fuel/HttpLoaderBuilderTest.kt
@@ -31,7 +31,7 @@ internal class HttpLoaderBuilderTest {
         mockWebServer.enqueue(MockResponse().setBody("Hello World"))
 
         val request = Request.Builder().data(mockWebServer.url("hello")).build()
-        val response = HttpLoader().get(request).response().body!!.string()
+        val response = HttpLoader().get(request).response().body.string()
         assertEquals("Hello World", response)
 
         mockWebServer.shutdown()
@@ -48,7 +48,7 @@ internal class HttpLoaderBuilderTest {
             .build()
 
         val request = Request.Builder().data(mockWebServer.url("hello")).build()
-        val response = httpLoader.get(request).response().body!!.string()
+        val response = httpLoader.get(request).response().body.string()
         assertEquals("Hello World", response)
     }
 
@@ -59,7 +59,7 @@ internal class HttpLoaderBuilderTest {
         val okhttp = OkHttpClient.Builder().callTimeout(30L, TimeUnit.MILLISECONDS).build()
         val httpLoader = FuelBuilder().okHttpClient(okhttp).build()
         val request = Request.Builder().data(mockWebServer.url("hello2")).build()
-        val response = httpLoader.get(request).response().body!!.string()
+        val response = httpLoader.get(request).response().body.string()
         assertEquals("Hello World 2", response)
     }
 
@@ -69,7 +69,7 @@ internal class HttpLoaderBuilderTest {
 
         val request = Request.Builder().data(mockWebServer.url("socket")).build()
         try {
-            HttpLoader().get(request).response().body!!.string()
+            HttpLoader().get(request).response().body.string()
         } catch (ste: SocketTimeoutException) {
             assertEquals("timeout", ste.message)
         }

--- a/fuel-base/src/test/kotlin/fuel/RealHttpLoaderTest.kt
+++ b/fuel-base/src/test/kotlin/fuel/RealHttpLoaderTest.kt
@@ -34,7 +34,7 @@ internal class RealHttpLoaderTest {
 
         val unsuccessfulRequest = Request.Builder().data(mockWebServer.url("get")).build()
 
-        val string = realHttpLoader.get(unsuccessfulRequest).response().body!!.string()
+        val string = realHttpLoader.get(unsuccessfulRequest).response().body.string()
 
         val request1 = mockWebServer.takeRequest()
 
@@ -48,7 +48,7 @@ internal class RealHttpLoaderTest {
 
         val request = Request.Builder().data(mockWebServer.url("get")).build()
 
-        val string = realHttpLoader.get(request).response().body!!.string()
+        val string = realHttpLoader.get(request).response().body.string()
 
         val request1 = mockWebServer.takeRequest()
 
@@ -160,7 +160,7 @@ internal class RealHttpLoaderTest {
             .requestBody(null)
             .build()
 
-        val string = realHttpLoader.delete(request).response().body!!.string()
+        val string = realHttpLoader.delete(request).response().body.string()
 
         val request1 = mockWebServer.takeRequest()
 

--- a/fuel-base/src/test/kotlin/fuel/RoutingTest.kt
+++ b/fuel-base/src/test/kotlin/fuel/RoutingTest.kt
@@ -63,7 +63,7 @@ internal class RoutingTest {
         mockWebServer.enqueue(MockResponse().setBody("Hello World"))
 
         val getTest = TestApi.GetTest(mockWebServer.url(""))
-        val response = HttpLoader().method(getTest.request).execute().body!!.string()
+        val response = HttpLoader().method(getTest.request).execute().body.string()
         val request1 = mockWebServer.takeRequest()
 
         assertEquals("Hello World", response)
@@ -75,7 +75,7 @@ internal class RoutingTest {
         mockWebServer.enqueue(MockResponse().setBody("Hello World With Params"))
 
         val getTest = TestApi.GetParamsTest(mockWebServer.url(""))
-        val response = HttpLoader().method(getTest.request).execute().body!!.string()
+        val response = HttpLoader().method(getTest.request).execute().body.string()
         val request1 = mockWebServer.takeRequest()
 
         assertEquals("Hello World With Params", response)

--- a/fuel-forge/src/main/kotlin/fuel/forge/ResponseExtension.kt
+++ b/fuel-forge/src/main/kotlin/fuel/forge/ResponseExtension.kt
@@ -6,4 +6,4 @@ import com.github.kittinunf.forge.core.JSON
 import okhttp3.Response
 
 public fun <T : Any> Response.toForge(deserializer: JSON.() -> DeserializedResult<T>): DeserializedResult<T> =
-    Forge.modelFromJson(body!!.string(), deserializer)
+    Forge.modelFromJson(body.string(), deserializer)

--- a/fuel-jackson/src/main/kotlin/fuel/jackson/ResponseExtension.kt
+++ b/fuel-jackson/src/main/kotlin/fuel/jackson/ResponseExtension.kt
@@ -10,4 +10,4 @@ public val defaultMapper: ObjectMapper = ObjectMapper().registerKotlinModule()
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
 public inline fun <reified T : Any> Response.toJackson(mapper: ObjectMapper = defaultMapper): T =
-    mapper.readValue(body!!.string())
+    mapper.readValue(body.string())

--- a/fuel-kotlinx-serialization/src/main/kotlin/fuel/serialization/ResponseExtension.kt
+++ b/fuel-kotlinx-serialization/src/main/kotlin/fuel/serialization/ResponseExtension.kt
@@ -7,4 +7,4 @@ import okhttp3.Response
 public fun <T : Any> Response.toJson(
     json: Json = Json { allowStructuredMapKeys = true },
     deserialization: DeserializationStrategy<T>
-): T = json.decodeFromString(deserialization, body!!.string())
+): T = json.decodeFromString(deserialization, body.string())

--- a/fuel-ktor/src/main/kotlin/fuel/ktor/FuelEngine.kt
+++ b/fuel-ktor/src/main/kotlin/fuel/ktor/FuelEngine.kt
@@ -191,9 +191,9 @@ private fun HttpRequestData.convertToFuelRequest(callContext: CoroutineContext):
 
         method(method.value)
 
-        val bodyBytes = if (HttpMethod.permitsRequestBody(method.value)) {
+        val bodyBytes = method.value.takeIf(HttpMethod::permitsRequestBody).let {
             body.convertToOkHttpBody(callContext)
-        } else null
+        }
 
         requestBody(bodyBytes)
     }

--- a/fuel-ktor/src/main/kotlin/fuel/ktor/FuelUtils.kt
+++ b/fuel-ktor/src/main/kotlin/fuel/ktor/FuelUtils.kt
@@ -29,4 +29,5 @@ internal fun Protocol.fromOkHttp(): HttpProtocolVersion = when (this) {
     Protocol.HTTP_2 -> HttpProtocolVersion.HTTP_2_0
     Protocol.H2_PRIOR_KNOWLEDGE -> HttpProtocolVersion.HTTP_2_0
     Protocol.QUIC -> HttpProtocolVersion.QUIC
+    Protocol.HTTP_3 -> HttpProtocolVersion("HTTP", 3, 0)
 }

--- a/fuel-moshi/src/main/kotlin/fuel/moshi/ResponseExtension.kt
+++ b/fuel-moshi/src/main/kotlin/fuel/moshi/ResponseExtension.kt
@@ -10,10 +10,10 @@ public val defaultMoshi: Moshi.Builder = Moshi.Builder()
 public inline fun <reified T : Any> Response.toMoshi(): T? = toMoshi(T::class.java)
 
 public fun <T : Any> Response.toMoshi(clazz: Class<T>): T? =
-    defaultMoshi.build().adapter(clazz).fromJson(body!!.source())
+    defaultMoshi.build().adapter(clazz).fromJson(body.source())
 
 public fun <T : Any> Response.toMoshi(type: Type): T? =
-    defaultMoshi.build().adapter<T>(type).fromJson(body!!.source())
+    defaultMoshi.build().adapter<T>(type).fromJson(body.source())
 
 public fun <T : Any> Response.toMoshi(jsonAdapter: JsonAdapter<T>): T? =
-    jsonAdapter.fromJson(body!!.source())
+    jsonAdapter.fromJson(body.source())

--- a/fuel-samples/progress/src/main/kotlin/fuel/samples/FuelProgress.kt
+++ b/fuel-samples/progress/src/main/kotlin/fuel/samples/FuelProgress.kt
@@ -32,12 +32,12 @@ fun main() {
     val client = OkHttpClient.Builder().addNetworkInterceptor {
         val originalResponse = it.proceed(it.request())
         originalResponse.newBuilder()
-            .body(ProgressResponseBody(originalResponse.body!!, progressListener))
+            .body(ProgressResponseBody(originalResponse.body, progressListener))
             .build()
     }.build()
     val httpLoader = FuelBuilder().okHttpClient(client).build()
     val request = Request.Builder().data("https://publicobject.com/helloworld.txt").build()
 
-    val string = httpLoader.get(request).execute().body!!.string()
+    val string = httpLoader.get(request).execute().body.string()
     println(string)
 }


### PR DESCRIPTION
### Description

- Use Kotlin 1.7.21 version 
- Update deps for 3.x version and remove some warnings

