### PR TITLE
Fix Maven Publications' Signing

### DIFF
--- a/plugins/src/main/kotlin/publication.gradle.kts
+++ b/plugins/src/main/kotlin/publication.gradle.kts
@@ -112,3 +112,8 @@ signing {
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign(publishing.publications)
 }
+
+// TODO: remove after https://youtrack.jetbrains.com/issue/KT-46466 is fixed
+project.tasks.withType(AbstractPublishToMaven::class.java).configureEach {
+    dependsOn(project.tasks.withType(Sign::class.java))
+}


### PR DESCRIPTION
This will fix Maven Signing with proper tasks by depending on the correct sign class. 