### PR TITLE
[Breaking Change] New builder pattern For Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,18 @@ use the `any http method` [suspend](https://kotlinlang.org/docs/reference/corout
 
 ```kotlin
 runBlocking {
-    val string = Fuel.get("https://publicobject.com/helloworld.txt").body!!.string()
+    val string = Fuel.get("https://publicobject.com/helloworld.txt").body.string()
     println(string)
 }
 
 runBlocking {
-    val string = "https://publicobject.com/helloworld.txt".httpGet().body!!.string()
+    val string = "https://publicobject.com/helloworld.txt".httpGet().body.string()
     println(string)
+}
+
+runBlocking {
+    val fuel = FuelBuilder().build()
+    val string = fuel.get(request = { url = "https://publicobject.com/helloworld.txt" }).body.string()
 }
 
 ```

--- a/fuel/src/appleMain/kotlin/fuel/AppleHttpLoader.kt
+++ b/fuel/src/appleMain/kotlin/fuel/AppleHttpLoader.kt
@@ -5,31 +5,43 @@ import platform.Foundation.NSURLSessionConfiguration
 public class AppleHttpLoader(sessionConfiguration: NSURLSessionConfiguration) : HttpLoader {
     private val fetcher by lazy { HttpUrlFetcher(sessionConfiguration) }
 
-    public override suspend fun get(request: Request): HttpResponse =
-        fetcher.fetch("GET", request)
-
-    public override suspend fun post(request: Request): HttpResponse {
-        requireNotNull(request.body) { "body for method POST should not be null" }
-        return fetcher.fetch("POST", request)
+    public override suspend fun get(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        return fetcher.fetch("GET", requestBuilder)
     }
 
-    public override suspend fun put(request: Request): HttpResponse {
-        requireNotNull(request.body) { "body for method PUT should not be null" }
-        return fetcher.fetch("PUT", request)
+    public override suspend fun post(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        requireNotNull(requestBuilder.body) { "body for method POST should not be null" }
+        return fetcher.fetch("POST", requestBuilder)
     }
 
-    public override suspend fun patch(request: Request): HttpResponse {
-        requireNotNull(request.body) { "body for method PATCH should not be null" }
-        return fetcher.fetch("PATCH", request)
+    public override suspend fun put(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        requireNotNull(requestBuilder.body) { "body for method PUT should not be null" }
+        return fetcher.fetch("PUT", requestBuilder)
     }
 
-    public override suspend fun delete(request: Request): HttpResponse = fetcher.fetch("DELETE", request)
+    public override suspend fun patch(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        requireNotNull(requestBuilder.body) { "body for method PATCH should not be null" }
+        return fetcher.fetch("PATCH", requestBuilder)
+    }
 
-    public override suspend fun head(request: Request): HttpResponse = fetcher.fetch("HEAD", request)
+    public override suspend fun delete(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        return fetcher.fetch("DELETE", requestBuilder)
+    }
 
-    public override suspend fun method(request: Request): HttpResponse {
-        val method = requireNotNull(request.method) { "method should be not null" }
-        return fetcher.fetch(method, request)
+    public override suspend fun head(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        return fetcher.fetch("HEAD", requestBuilder)
+    }
+
+    public override suspend fun method(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        val method = requireNotNull(requestBuilder.method) { "method should be not null" }
+        return fetcher.fetch(method, requestBuilder)
     }
 
     public companion object {

--- a/fuel/src/commonMain/kotlin/fuel/Fuels.kt
+++ b/fuel/src/commonMain/kotlin/fuel/Fuels.kt
@@ -4,79 +4,67 @@ public suspend fun Fuel.get(
     url: String,
     parameters: Parameters? = null,
     headers: Map<String, String> = emptyMap()
-): HttpResponse = loader().get(
-    Request.Builder()
-        .url(url)
-        .parameters(parameters)
-        .headers(headers)
-        .build()
-)
+): HttpResponse = loader().get {
+    this.url = url
+    this.parameters = parameters
+    this.headers = headers
+}
 
 public suspend fun Fuel.post(
     url: String,
     parameters: Parameters? = null,
     body: String? = null,
     headers: Map<String, String> = emptyMap()
-): HttpResponse = loader().post(
-    Request.Builder()
-        .url(url)
-        .parameters(parameters)
-        .headers(headers)
-        .body(body)
-        .build()
-)
+): HttpResponse = loader().post {
+    this.url = url
+    this.parameters = parameters
+    this.body = body
+    this.headers = headers
+}
 
 public suspend fun Fuel.put(
     url: String,
     parameters: Parameters? = null,
     body: String? = null,
     headers: Map<String, String> = emptyMap()
-): HttpResponse = loader().put(
-    Request.Builder()
-        .url(url)
-        .parameters(parameters)
-        .headers(headers)
-        .body(body)
-        .build()
-)
+): HttpResponse = loader().put {
+    this.url = url
+    this.parameters = parameters
+    this.headers = headers
+    this.body = body
+}
 
 public suspend fun Fuel.patch(
     url: String,
     parameters: Parameters? = null,
     body: String? = null,
     headers: Map<String, String> = emptyMap()
-): HttpResponse = loader().patch(
-    Request.Builder()
-        .url(url)
-        .parameters(parameters)
-        .headers(headers)
-        .body(body)
-        .build()
-)
+): HttpResponse = loader().patch {
+    this.url = url
+    this.parameters = parameters
+    this.body = body
+    this.headers = headers
+}
 
 public suspend fun Fuel.delete(
     url: String,
     parameters: Parameters? = null,
     body: String? = null,
     headers: Map<String, String> = emptyMap()
-): HttpResponse = loader().delete(
-    Request.Builder()
-        .url(url)
-        .parameters(parameters)
-        .headers(headers)
-        .body(body)
-        .build()
-)
+): HttpResponse = loader().delete {
+    this.url = url
+    this.parameters = parameters
+    this.body = body
+    this.headers = headers
+}
 
 public suspend fun Fuel.head(
     url: String,
     parameters: Parameters? = null
-): HttpResponse = loader().head(
-    Request.Builder()
-        .url(url)
-        .parameters(parameters)
-        .build()
-)
+): HttpResponse = loader().head {
+    this.url = url
+    this.parameters = parameters
+}
 
 public suspend fun Fuel.method(
     url: String,
@@ -84,15 +72,21 @@ public suspend fun Fuel.method(
     method: String? = null,
     body: String? = null,
     headers: Map<String, String> = emptyMap()
-): HttpResponse = loader().method(
-    Request.Builder()
-        .url(url)
-        .parameters(parameters)
-        .method(method)
-        .headers(headers)
-        .body(body)
-        .build()
-)
+): HttpResponse = loader().method {
+    this.url = url
+    this.parameters = parameters
+    this.method = method
+    this.body = body
+    this.headers = headers
+}
 
-public suspend fun Fuel.request(convertible: RequestConvertible): HttpResponse =
-    loader().method(convertible.request)
+public suspend fun Fuel.request(convertible: RequestConvertible): HttpResponse {
+    val request = convertible.request
+    return loader().method {
+        url = request.url
+        parameters = request.parameters
+        method = request.method
+        body = request.body
+        headers = request.headers ?: emptyMap()
+    }
+}

--- a/fuel/src/commonMain/kotlin/fuel/HttpLoader.kt
+++ b/fuel/src/commonMain/kotlin/fuel/HttpLoader.kt
@@ -1,11 +1,11 @@
 package fuel
 
 public interface HttpLoader {
-    public suspend fun get(request: Request): HttpResponse
-    public suspend fun post(request: Request): HttpResponse
-    public suspend fun put(request: Request): HttpResponse
-    public suspend fun patch(request: Request): HttpResponse
-    public suspend fun delete(request: Request): HttpResponse
-    public suspend fun head(request: Request): HttpResponse
-    public suspend fun method(request: Request): HttpResponse
+    public suspend fun get(request: Request.Builder.() -> Unit): HttpResponse
+    public suspend fun post(request: Request.Builder.() -> Unit): HttpResponse
+    public suspend fun put(request: Request.Builder.() -> Unit): HttpResponse
+    public suspend fun patch(request: Request.Builder.() -> Unit): HttpResponse
+    public suspend fun delete(request: Request.Builder.() -> Unit): HttpResponse
+    public suspend fun head(request: Request.Builder.() -> Unit): HttpResponse
+    public suspend fun method(request: Request.Builder.() -> Unit): HttpResponse
 }

--- a/fuel/src/commonMain/kotlin/fuel/Request.kt
+++ b/fuel/src/commonMain/kotlin/fuel/Request.kt
@@ -2,55 +2,31 @@ package fuel
 
 public typealias Parameters = List<Pair<String, String>>
 
-public class Request internal constructor(
+public class Request(
     public val url: String,
     public val parameters: Parameters?,
     public val headers: Map<String, String>?,
     public val body: String?,
     public val method: String?
 ) {
-    public open class Builder {
-        private var url: String? = null
-        private var headers = emptyMap<String, String>()
-        private var body: String? = null
-        private var method: String? = null
-        private var parameters: Parameters? = null
+    private constructor(builder: Builder) : this(
+        checkNotNull(builder.url) { "url == null" },
+        builder.parameters,
+        builder.headers,
+        builder.body,
+        builder.method
+    )
 
-        /**
-         * Set the url to load
-         */
-        public fun url(url: String): Builder = apply {
-            this.url = url
-        }
-
-        public fun parameters(parameters: Parameters?): Builder = apply {
-            this.parameters = parameters
-        }
-
-        /**
-         * Set the [MutableMap] for any network operations performed by this request.
-         */
-        public fun headers(headers: Map<String, String>): Builder = apply {
-            this.headers = headers
-        }
-
-        public fun body(body: String?): Builder = apply {
-            this.body = body
-        }
-
-        public fun method(method: String?): Builder = apply {
-            this.method = method
-        }
+    public class Builder {
+        public var url: String? = null
+        public var headers: Map<String, String> = emptyMap()
+        public var body: String? = null
+        public var method: String? = null
+        public var parameters: Parameters? = null
 
         /**
          * Create a new [Request] instance.
          */
-        public fun build(): Request = Request(
-            checkNotNull(url) { "url == null" },
-            parameters,
-            headers,
-            body,
-            method
-        )
+        public fun build(): Request = Request(this)
     }
 }

--- a/fuel/src/commonTest/kotlin/fuel/RequestTest.kt
+++ b/fuel/src/commonTest/kotlin/fuel/RequestTest.kt
@@ -5,10 +5,10 @@ import kotlin.test.assertEquals
 internal class RequestTest {
     @Test
     fun testAdd_headers() {
-        val request = Request.Builder()
-            .url("http://example.com")
-            .headers(mapOf("X-Test" to "true"))
-            .build()
+        val request = Request.Builder().apply {
+            url = "http://example.com"
+            headers = mapOf("X-Test" to "true")
+        }.build()
         assertEquals("true", request.headers?.get("X-Test"))
     }
 

--- a/fuel/src/jsMain/kotlin/fuel/JSHttpLoader.kt
+++ b/fuel/src/jsMain/kotlin/fuel/JSHttpLoader.kt
@@ -3,35 +3,42 @@ package fuel
 public class JSHttpLoader : HttpLoader {
     private val fetcher by lazy { HttpUrlFetcher() }
 
-    public override suspend fun get(request: Request): HttpResponse {
-        return fetcher.fetch(request, "GET")
+    public override suspend fun get(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        return fetcher.fetch(requestBuilder, "GET")
     }
 
-    public override suspend fun post(request: Request): HttpResponse {
-        requireNotNull(request.body) { "body for method POST should not be null" }
-        return fetcher.fetch(request, "POST", request.body)
+    public override suspend fun post(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        requireNotNull(requestBuilder.body) { "body for method POST should not be null" }
+        return fetcher.fetch(requestBuilder, "POST", requestBuilder.body)
     }
 
-    public override suspend fun put(request: Request): HttpResponse {
-        requireNotNull(request.body) { "body for method POST should not be null" }
-        return fetcher.fetch(request, "PUT", request.body)
+    public override suspend fun put(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        requireNotNull(requestBuilder.body) { "body for method POST should not be null" }
+        return fetcher.fetch(requestBuilder, "PUT", requestBuilder.body)
     }
 
-    public override suspend fun patch(request: Request): HttpResponse {
-        requireNotNull(request.body) { "body for method POST should not be null" }
-        return fetcher.fetch(request, "PATCH", request.body)
+    public override suspend fun patch(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        requireNotNull(requestBuilder.body) { "body for method POST should not be null" }
+        return fetcher.fetch(requestBuilder, "PATCH", requestBuilder.body)
     }
 
-    public override suspend fun delete(request: Request): HttpResponse {
-        return fetcher.fetch(request, "DELETE")
+    public override suspend fun delete(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        return fetcher.fetch(requestBuilder, "DELETE")
     }
 
-    public override suspend fun head(request: Request): HttpResponse {
-        return fetcher.fetch(request, "HEAD")
+    public override suspend fun head(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        return fetcher.fetch(requestBuilder, "HEAD")
     }
 
-    public override suspend fun method(request: Request): HttpResponse {
-        val method = requireNotNull(request.method) { "method should be not null" }
-        return fetcher.fetch(request, method, request.body)
+    public override suspend fun method(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        val method = requireNotNull(requestBuilder.method) { "method should be not null" }
+        return fetcher.fetch(requestBuilder, method, requestBuilder.body)
     }
 }

--- a/fuel/src/jvmMain/kotlin/fuel/JVMHttpLoader.kt
+++ b/fuel/src/jvmMain/kotlin/fuel/JVMHttpLoader.kt
@@ -9,36 +9,57 @@ import okhttp3.internal.http.HttpMethod
 public class JVMHttpLoader(callFactoryLazy: Lazy<Call.Factory>) : HttpLoader {
     private val fetcher: HttpUrlFetcher by lazy { HttpUrlFetcher(callFactoryLazy) }
 
-    public override suspend fun get(request: Request): HttpResponse {
-        return fetcher.fetch(request, createRequestBuilder(request, "GET")).performAsync()
+    public override suspend fun get(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        return fetcher
+            .fetch(requestBuilder, createRequestBuilder(requestBuilder, "GET"))
+            .performAsync()
     }
 
-    public override suspend fun post(request: Request): HttpResponse {
-        requireNotNull(request.body) { "body for method POST should not be null" }
-        return fetcher.fetch(request, createRequestBuilder(request, "POST")).performAsync()
+    public override suspend fun post(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        requireNotNull(requestBuilder.body) { "body for method POST should not be null" }
+        return fetcher
+            .fetch(requestBuilder, createRequestBuilder(requestBuilder, "POST"))
+            .performAsync()
     }
 
-    public override suspend fun put(request: Request): HttpResponse {
-        requireNotNull(request.body) { "body for method PUT should not be null" }
-        return fetcher.fetch(request, createRequestBuilder(request, "PUT")).performAsync()
+    public override suspend fun put(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        requireNotNull(requestBuilder.body) { "body for method PUT should not be null" }
+        return fetcher
+            .fetch(requestBuilder, createRequestBuilder(requestBuilder, "PUT"))
+            .performAsync()
     }
 
-    public override suspend fun patch(request: Request): HttpResponse {
-        requireNotNull(request.body) { "body for method PATCH should not be null" }
-        return fetcher.fetch(request, createRequestBuilder(request, "PATCH")).performAsync()
+    public override suspend fun patch(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        requireNotNull(requestBuilder.body) { "body for method PATCH should not be null" }
+        return fetcher
+            .fetch(requestBuilder, createRequestBuilder(requestBuilder, "PATCH"))
+            .performAsync()
     }
 
-    public override suspend fun delete(request: Request): HttpResponse {
-        return fetcher.fetch(request, createRequestBuilder(request, "DELETE")).performAsync()
+    public override suspend fun delete(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        return fetcher
+            .fetch(requestBuilder, createRequestBuilder(requestBuilder, "DELETE"))
+            .performAsync()
     }
 
-    public override suspend fun head(request: Request): HttpResponse {
-        return fetcher.fetch(request, createRequestBuilder(request, "HEAD")).performAsync()
+    public override suspend fun head(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        return fetcher
+            .fetch(requestBuilder, createRequestBuilder(requestBuilder, "HEAD"))
+            .performAsync()
     }
 
-    public override suspend fun method(request: Request): HttpResponse {
-        val method = requireNotNull(request.method) { "method should be not null" }
-        return fetcher.fetch(request, createRequestBuilder(request, method)).performAsync()
+    public override suspend fun method(request: Request.Builder.() -> Unit): HttpResponse {
+        val requestBuilder = Request.Builder().apply(request).build()
+        val method = requireNotNull(requestBuilder.method) { "method should be not null" }
+        return fetcher
+            .fetch(requestBuilder, createRequestBuilder(requestBuilder, method))
+            .performAsync()
     }
 
     private suspend fun Call.performAsync(): HttpResponse {

--- a/fuel/src/jvmTest/kotlin/fuel/HttpLoaderBuilderTest.kt
+++ b/fuel/src/jvmTest/kotlin/fuel/HttpLoaderBuilderTest.kt
@@ -30,9 +30,9 @@ internal class HttpLoaderBuilderTest {
     @Test
     fun `default okhttp settings`() = runBlocking {
         mockWebServer.enqueue(MockResponse().setBody("Hello World"))
-
-        val request = Request.Builder().url(mockWebServer.url("hello").toString()).build()
-        val response = JVMHttpLoader().get(request).body.string()
+        val response = JVMHttpLoader().get {
+            url = mockWebServer.url("hello").toString()
+        }.body.string()
         assertEquals("Hello World", response)
 
         mockWebServer.shutdown()
@@ -47,9 +47,9 @@ internal class HttpLoaderBuilderTest {
                 OkHttpClient.Builder().connectTimeout(30L, TimeUnit.MILLISECONDS).build()
             }
             .build()
-
-        val request = Request.Builder().url(mockWebServer.url("hello").toString()).build()
-        val response = httpLoader.get(request).body.string()
+        val response = httpLoader.get {
+            url = mockWebServer.url("hello").toString()
+        }.body.string()
         assertEquals("Hello World", response)
     }
 
@@ -59,18 +59,19 @@ internal class HttpLoaderBuilderTest {
 
         val okhttp = OkHttpClient.Builder().callTimeout(30L, TimeUnit.MILLISECONDS).build()
         val httpLoader = FuelBuilder().config(okhttp).build()
-        val request = Request.Builder().url(mockWebServer.url("hello2").toString()).build()
-        val response = httpLoader.get(request).body.string()
+        val response = httpLoader.get {
+            url = mockWebServer.url("hello2").toString()
+        }.body.string()
         assertEquals("Hello World 2", response)
     }
 
     @Test
     fun `no socket response`(): Unit = runBlocking {
         mockWebServer.enqueue(MockResponse().setBody("{}").setSocketPolicy(SocketPolicy.NO_RESPONSE))
-
-        val request = Request.Builder().url(mockWebServer.url("socket").toString()).build()
         try {
-            JVMHttpLoader().get(request).body.string()
+            JVMHttpLoader().get {
+                url = mockWebServer.url("socket").toString()
+            }.body.string()
         } catch (ste: SocketTimeoutException) {
             assertNotNull(ste, "socket timeout")
         }

--- a/fuel/src/jvmTest/kotlin/fuel/HttpLoaderTest.kt
+++ b/fuel/src/jvmTest/kotlin/fuel/HttpLoaderTest.kt
@@ -73,7 +73,7 @@ internal class HttpLoaderTest {
 
         val string = httpLoader.get {
             url = mockWebServer.url("get").toString()
-            parameters = listOf("foo" to "bar")
+            headers = mapOf("foo" to "bar")
         }.body.string()
 
         val request1 = mockWebServer.takeRequest()

--- a/fuel/src/jvmTest/kotlin/fuel/HttpLoaderTest.kt
+++ b/fuel/src/jvmTest/kotlin/fuel/HttpLoaderTest.kt
@@ -28,9 +28,9 @@ internal class HttpLoaderTest {
     fun `unsuccessful 404 Error`() = runBlocking {
         mockWebServer.enqueue(MockResponse().setResponseCode(404).setBody("Hello World"))
 
-        val unsuccessfulRequest = Request.Builder().url(mockWebServer.url("get").toString()).build()
-
-        val string = httpLoader.get(unsuccessfulRequest).body.string()
+        val string = httpLoader.get {
+            url = mockWebServer.url("get").toString()
+        }.body.string()
 
         val request1 = mockWebServer.takeRequest()
 
@@ -42,9 +42,9 @@ internal class HttpLoaderTest {
     fun `get test data`() = runBlocking {
         mockWebServer.enqueue(MockResponse().setBody("Hello World"))
 
-        val request = Request.Builder().url(mockWebServer.url("get").toString()).build()
-
-        val string = httpLoader.get(request).body.string()
+        val string = httpLoader.get {
+            url = mockWebServer.url("get").toString()
+        }.body.string()
 
         val request1 = mockWebServer.takeRequest()
 
@@ -56,12 +56,10 @@ internal class HttpLoaderTest {
     fun `get test data with parameters`() = runBlocking {
         mockWebServer.enqueue(MockResponse().setBody("Hello There"))
 
-        val request = Request.Builder()
-            .url(mockWebServer.url("get").toString())
-            .parameters(listOf("foo" to "bar"))
-            .build()
-
-        val string = httpLoader.get(request).body.string()
+        val string = httpLoader.get {
+            url = mockWebServer.url("get").toString()
+            parameters = listOf("foo" to "bar")
+        }.body.string()
 
         val request1 = mockWebServer.takeRequest()
 
@@ -73,12 +71,10 @@ internal class HttpLoaderTest {
     fun `get test data with headers`() = runBlocking {
         mockWebServer.enqueue(MockResponse().setBody("Greeting Everyone"))
 
-        val request = Request.Builder()
-            .url(mockWebServer.url("get").toString())
-            .headers(mapOf("Foo" to "bar"))
-            .build()
-
-        val string = httpLoader.get(request).body.string()
+        val string = httpLoader.get {
+            url = mockWebServer.url("get").toString()
+            parameters = listOf("foo" to "bar")
+        }.body.string()
 
         val request1 = mockWebServer.takeRequest()
 
@@ -90,12 +86,10 @@ internal class HttpLoaderTest {
     fun `post test data`() = runBlocking {
         mockWebServer.enqueue(MockResponse())
 
-        val request = Request.Builder()
-            .url(mockWebServer.url("post").toString())
-            .body("Hi?")
-            .build()
-
-        httpLoader.post(request)
+        httpLoader.post {
+            url = mockWebServer.url("post").toString()
+            body = "Hi?"
+        }
         val request1 = mockWebServer.takeRequest()
 
         assertEquals("POST", request1.method)
@@ -107,9 +101,9 @@ internal class HttpLoaderTest {
     fun `empty response body for post`() = runBlocking {
         mockWebServer.enqueue(MockResponse())
 
-        val request = Request.Builder().url(mockWebServer.url("post").toString()).build()
-
-        httpLoader.post(request)
+        httpLoader.post {
+            url = mockWebServer.url("post").toString()
+        }
 
         val request1 = mockWebServer.takeRequest()
         assertEquals("POST", request1.method)
@@ -119,12 +113,10 @@ internal class HttpLoaderTest {
     fun `put test data`() = runBlocking {
         mockWebServer.enqueue(MockResponse())
 
-        val request = Request.Builder()
-            .url(mockWebServer.url("put").toString())
-            .body("Put There")
-            .build()
-
-        httpLoader.put(request)
+        httpLoader.put {
+            url = mockWebServer.url("put").toString()
+            body = "Put There"
+        }
 
         val request1 = mockWebServer.takeRequest()
 
@@ -137,9 +129,9 @@ internal class HttpLoaderTest {
     fun `empty response body for put`() = runBlocking {
         mockWebServer.enqueue(MockResponse())
 
-        val request = Request.Builder().url(mockWebServer.url("put").toString()).build()
-
-        httpLoader.put(request)
+        httpLoader.put {
+            url = mockWebServer.url("put").toString()
+        }
 
         val request1 = mockWebServer.takeRequest()
 
@@ -150,12 +142,10 @@ internal class HttpLoaderTest {
     fun `patch test data`() = runBlocking {
         mockWebServer.enqueue(MockResponse())
 
-        val request = Request.Builder()
-            .url(mockWebServer.url("patch").toString())
-            .body("Hello There")
-            .build()
-
-        httpLoader.patch(request)
+        httpLoader.patch {
+            url = mockWebServer.url("patch").toString()
+            body = "Hello There"
+        }
 
         val request1 = mockWebServer.takeRequest()
 
@@ -168,9 +158,9 @@ internal class HttpLoaderTest {
     fun `empty response body for patch`() = runBlocking {
         mockWebServer.enqueue(MockResponse())
 
-        val request = Request.Builder().url(mockWebServer.url("patch").toString()).build()
-
-        httpLoader.patch(request)
+        httpLoader.patch {
+            url = mockWebServer.url("patch").toString()
+        }
 
         val request1 = mockWebServer.takeRequest()
 
@@ -181,11 +171,9 @@ internal class HttpLoaderTest {
     fun `delete test data`() = runBlocking {
         mockWebServer.enqueue(MockResponse().setBody("Hello World"))
 
-        val request = Request.Builder()
-            .url(mockWebServer.url("delete").toString())
-            .build()
-
-        val string = httpLoader.delete(request).body.string()
+        val string = httpLoader.delete {
+            url = mockWebServer.url("delete").toString()
+        }.body.string()
 
         val request1 = mockWebServer.takeRequest()
 
@@ -197,9 +185,9 @@ internal class HttpLoaderTest {
     fun `head test data`() = runBlocking {
         mockWebServer.enqueue(MockResponse())
 
-        val request = Request.Builder().url(mockWebServer.url("head").toString()).build()
-
-        httpLoader.head(request)
+        httpLoader.head {
+            url = mockWebServer.url("head").toString()
+        }
 
         val request1 = mockWebServer.takeRequest()
 
@@ -210,12 +198,10 @@ internal class HttpLoaderTest {
     fun `connect test data`() = runBlocking {
         mockWebServer.enqueue(MockResponse())
 
-        val request = Request.Builder()
-            .url(mockWebServer.url("connect").toString())
-            .method("CONNECT")
-            .build()
-
-        httpLoader.method(request)
+        httpLoader.method {
+            url = mockWebServer.url("connect").toString()
+            method = "CONNECT"
+        }
 
         val request1 = mockWebServer.takeRequest()
 
@@ -226,9 +212,9 @@ internal class HttpLoaderTest {
     fun `empty method for CONNECT`() = runBlocking {
         mockWebServer.enqueue(MockResponse())
 
-        val request = Request.Builder().url(mockWebServer.url("connect").toString()).build()
-
-        httpLoader.method(request)
+        httpLoader.method {
+            url = mockWebServer.url("connect").toString()
+        }
 
         val request1 = mockWebServer.takeRequest()
 

--- a/fuel/src/jvmTest/kotlin/fuel/HttpLoaderTest.kt
+++ b/fuel/src/jvmTest/kotlin/fuel/HttpLoaderTest.kt
@@ -46,9 +46,9 @@ internal class HttpLoaderTest {
             url = mockWebServer.url("get").toString()
         }.body.string()
 
-        val request1 = mockWebServer.takeRequest()
+        val request2 = mockWebServer.takeRequest()
 
-        assertEquals("GET", request1.method)
+        assertEquals("GET", request2.method)
         assertEquals(string, "Hello World")
     }
 

--- a/fuel/src/jvmTest/kotlin/fuel/RoutingTest.kt
+++ b/fuel/src/jvmTest/kotlin/fuel/RoutingTest.kt
@@ -64,7 +64,7 @@ internal class RoutingTest {
         mockWebServer.enqueue(MockResponse().setBody("Hello World"))
 
         val getTest = TestApi.GetTest(mockWebServer.url("").toString())
-        val response = JVMHttpLoader().method(getTest.request).body.string()
+        val response = Fuel.request(getTest).body.string()
         val request1 = mockWebServer.takeRequest()
 
         assertEquals("Hello World", response)
@@ -76,7 +76,7 @@ internal class RoutingTest {
         mockWebServer.enqueue(MockResponse().setBody("Hello World With Params"))
 
         val getTest = TestApi.GetParamsTest(mockWebServer.url("").toString())
-        val response = JVMHttpLoader().method(getTest.request).body.string()
+        val response = Fuel.request(getTest).body.string()
         val request1 = mockWebServer.takeRequest()
 
         assertEquals("Hello World With Params", response)

--- a/samples/mockbin-native/src/commonMain/kotlin/Main.kt
+++ b/samples/mockbin-native/src/commonMain/kotlin/Main.kt
@@ -1,13 +1,11 @@
 import fuel.FuelBuilder
-import fuel.Request
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
     val fuel = FuelBuilder().build()
-    val request = Request.Builder()
-        .body("{\"foo\": \"bar\"}")
-        .url("http://mockbin.com/request?foo=bar&foo=baz")
-        .build()
-    val response = fuel.post(request)
+    val response = fuel.post(request = {
+        url = "http://mockbin.com/request?foo=bar&foo=baz"
+        body = "{\"foo\": \"bar\"}"
+    })
     println(response.body)
 }


### PR DESCRIPTION
old way is 

```
loader().get(
    Request.Builder()
        .url(url)
        .parameters(parameters)
        .headers(headers)
        .build()
)
```

new way is 
```
loader().get {
    this.url = url
    this.parameters = parameters
    this.headers = headers
}
```

I think it is more simplified to cut down on verbose with more type-safe builder patterns. I am wondering if somebody may have a problem with this. 