### PR TITLE
[Fix] Fix publishing task to include sourceJa after verification process is failing

### DIFF
--- a/fuel-forge-jvm/build.gradle.kts
+++ b/fuel-forge-jvm/build.gradle.kts
@@ -8,6 +8,11 @@ kotlin {
     explicitApi()
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 tasks.withType<JavaCompile> {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()

--- a/fuel-jackson-jvm/build.gradle.kts
+++ b/fuel-jackson-jvm/build.gradle.kts
@@ -8,6 +8,11 @@ kotlin {
     explicitApi()
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 tasks.withType<JavaCompile> {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()

--- a/fuel-moshi-jvm/build.gradle.kts
+++ b/fuel-moshi-jvm/build.gradle.kts
@@ -9,6 +9,11 @@ kotlin {
     explicitApi()
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 tasks.withType<JavaCompile> {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,5 @@ artifactUrl=https://github.com/kittinunf/fuel
 artifactScm=git@github.com:kittinunf/fuel.git
 artifactLicenseName=MIT License
 artifactLicenseUrl=http://www.opensource.org/licenses/mit-license.php
-artifactPublishVersion=3.0.0-alpha2
+artifactPublishVersion=3.0.0-alpha02
 artifactGroupId=com.github.kittinunf.fuel

--- a/plugins/src/main/kotlin/publication.gradle.kts
+++ b/plugins/src/main/kotlin/publication.gradle.kts
@@ -72,7 +72,9 @@ publishing {
 
         artifactId = project.name
 
-        artifact(javadocJar)
+        if (project.name.substringAfterLast("-") != "jvm") {
+            artifact(javadocJar)
+        }
 
         pom {
             name.set(artifactName)


### PR DESCRIPTION
### What's in this PR?

This PR fixes our gradle script a bit for publishing task when we publish the jar to sonatype.
Also it looks like we use `alpha0x` for naming convention so we are fixing that too.