### PR TITLE
Add missing commonMain folder to fuel-kotlinx-serialization project

### DIFF
--- a/fuel-kotlinx-serialization/src/commonMain/kotlin/fuel/serialization/ResponseExtensions.kt
+++ b/fuel-kotlinx-serialization/src/commonMain/kotlin/fuel/serialization/ResponseExtensions.kt
@@ -1,14 +1,11 @@
 package fuel.serialization
 
 import com.github.kittinunf.result.Result
-import com.github.kittinunf.result.runCatching
 import fuel.HttpResponse
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 
-public actual fun <T : Any> HttpResponse.toJson(
-    json: Json,
+public expect fun <T : Any> HttpResponse.toJson(
+    json: Json = Json { allowStructuredMapKeys = true },
     deserializationStrategy: DeserializationStrategy<T>
-): Result<T?, Throwable> = runCatching {
-    body?.let { json.decodeFromString(deserializationStrategy, it) }
-}
+): Result<T?, Throwable>

--- a/fuel-kotlinx-serialization/src/commonMain/kotlin/fuel/serialization/ResponseExtensions.kt
+++ b/fuel-kotlinx-serialization/src/commonMain/kotlin/fuel/serialization/ResponseExtensions.kt
@@ -6,6 +6,6 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 
 public expect fun <T : Any> HttpResponse.toJson(
-    json: Json = Json { allowStructuredMapKeys = true },
+    json: Json = Json,
     deserializationStrategy: DeserializationStrategy<T>
 ): Result<T?, Throwable>

--- a/fuel-kotlinx-serialization/src/commonMain/kotlin/fuel/serialization/ResponseExtensions.kt
+++ b/fuel-kotlinx-serialization/src/commonMain/kotlin/fuel/serialization/ResponseExtensions.kt
@@ -9,3 +9,4 @@ public expect fun <T : Any> HttpResponse.toJson(
     json: Json = Json { allowStructuredMapKeys = true },
     deserializationStrategy: DeserializationStrategy<T>
 ): Result<T?, Throwable>
+    

--- a/fuel-kotlinx-serialization/src/commonMain/kotlin/fuel/serialization/ResponseExtensions.kt
+++ b/fuel-kotlinx-serialization/src/commonMain/kotlin/fuel/serialization/ResponseExtensions.kt
@@ -9,4 +9,3 @@ public expect fun <T : Any> HttpResponse.toJson(
     json: Json = Json { allowStructuredMapKeys = true },
     deserializationStrategy: DeserializationStrategy<T>
 ): Result<T?, Throwable>
-    

--- a/fuel-kotlinx-serialization/src/jsMain/kotlin/fuel/serialization/ResponseExtensions.kt
+++ b/fuel-kotlinx-serialization/src/jsMain/kotlin/fuel/serialization/ResponseExtensions.kt
@@ -6,8 +6,8 @@ import fuel.HttpResponse
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 
-public fun <T : Any> HttpResponse.toJson(
-    json: Json = Json { allowStructuredMapKeys = true },
+public actual fun <T : Any> HttpResponse.toJson(
+    json: Json,
     deserializationStrategy: DeserializationStrategy<T>
 ): Result<T?, Throwable> = runCatching {
     json.decodeFromString(deserializationStrategy, response?.json().toString())

--- a/fuel-kotlinx-serialization/src/jvmMain/kotlin/fuel/serialization/ResponseExtensions.kt
+++ b/fuel-kotlinx-serialization/src/jvmMain/kotlin/fuel/serialization/ResponseExtensions.kt
@@ -6,8 +6,8 @@ import fuel.HttpResponse
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 
-public fun <T : Any> HttpResponse.toJson(
-    json: Json = Json { allowStructuredMapKeys = true },
+public actual fun <T : Any> HttpResponse.toJson(
+    json: Json,
     deserializationStrategy: DeserializationStrategy<T>
 ): Result<T?, Throwable> = runCatching {
     json.decodeFromString(deserializationStrategy, body.string())


### PR DESCRIPTION
### Description

This pull request adds the `commonMain` folder to the `fuel-kotlinx-serialization` project. The `commonMain` folder is necessary for the Kotlin Multiplatform setup and was missing from the project.

### Changes Made

- Added the `src/commonMain` directory.
- Defined an `expect` function `HttpResponse.toJson`
- Provided `actual` implementations for every platforms

### Motivation and Context

This change is required to properly organize the common code shared across different Kotlin Multiplatform platform platforms. Without this folder, the project setup is incomplete and may lead to build issues.