### PR TITLE
Fixing some Github Actions files for the deprecated functionality 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,17 +14,16 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Gradle build
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: build -x iosX64Test
+        run: ./gradlew build -x iosX64Test
 
       - name: Publish to SNAPSHOT
-        uses: gradle/actions/setup-gradle@v3
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        with:
-          arguments: publishAllPublicationsToSonatypeRepository --max-workers 1
+        run: ./gradlew publishAllPublicationsToSonatypeRepository --max-workers 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,8 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Gradle build
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: build -x iosX64Test
+
+      - name: Gradle build
+        run: ./gradlew build -x iosX64Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,16 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Gradle build
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: build -x iosX64Test
+        run: ./gradlew build -x iosX64Test
 
       - name: Publish to MavenCentral
-        uses: gradle/actions/setup-gradle@v3
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        with:
-          arguments: publish --max-workers 1 -Prelease=true
+        run: ./gradlew publish --max-workers 1 -Prelease=true


### PR DESCRIPTION
Replace gradle/gradle-build-action with gradle/actions/setup-gradle by removing arguments so that we can use run for it. 