### PR TITLE
[Fix] Fix snapshots host

### DIFF
--- a/plugins/src/main/kotlin/publication.gradle.kts
+++ b/plugins/src/main/kotlin/publication.gradle.kts
@@ -42,7 +42,7 @@ publishing {
                     if (isReleaseBuild) {
                         "https://oss.sonatype.org/service/local/staging/deploy/maven2"
                     } else {
-                        "https://oss.sonatype.org/content/repositories/snapshots"
+                        "https://s01.oss.sonatype.org/content/repositories/snapshots"
                     },
                 )
 


### PR DESCRIPTION
### What's in this PR?

Seems like our snapshots might point to the wrong location, this PR fixes this.

`oss.sonatype.org` -> `s01.oss.sonatype.org`