### PR TITLE
Update to Kotlin 2.1.0 and Adjustments for WasmJS API Changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("multiplatform") version "2.0.21" apply false
+    kotlin("multiplatform") version "2.1.0" apply false
     id("org.jetbrains.kotlinx.kover") version "0.9.0" apply false
 }
 

--- a/fuel-kotlinx-serialization/build.gradle.kts
+++ b/fuel-kotlinx-serialization/build.gradle.kts
@@ -1,10 +1,9 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "2.0.21"
+    kotlin("plugin.serialization") version "2.1.0"
     id("publication")
     id("org.jetbrains.kotlinx.kover")
 }
@@ -18,11 +17,6 @@ kotlin {
         testRuns["test"].executionTask.configure {
             useJUnit()
         }
-    }
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs {
-        browser()
-        binaries.executable()
     }
     iosArm64 {
         binaries {

--- a/fuel-moshi-jvm/build.gradle.kts
+++ b/fuel-moshi-jvm/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("jvm")
     id("publication")
     id("org.jetbrains.kotlinx.kover")
-    id("com.google.devtools.ksp") version "2.0.21-1.0.28"
+    id("com.google.devtools.ksp") version "2.1.0-1.0.29"
 }
 
 kotlin {

--- a/fuel/build.gradle.kts
+++ b/fuel/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -17,11 +16,6 @@ kotlin {
         testRuns["test"].executionTask.configure {
             useJUnit()
         }
-    }
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs {
-        browser()
-        binaries.executable()
     }
     iosArm64 {
         binaries {
@@ -65,14 +59,6 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
-
-    /*targets.configureEach {
-        compilations.configureEach {
-            compilerOptions.configure {
-                freeCompilerArgs.add("-Xexpect-actual-classes")
-            }
-        }
-    }*/
 
     sourceSets {
         commonMain {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-coroutines = "1.9.0"
-jackson = "2.18.2"
+coroutines = "1.10.1"
+jackson = "2.17.2"
 junit = "4.13.2"
 moshi = "1.15.2"
 okhttp = "5.0.0-alpha.14"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ include(":fuel-jackson-jvm")
 include(":fuel-kotlinx-serialization")
 include(":fuel-moshi-jvm")
 
-include(":samples:httpbin-wasm")
+//include(":samples:httpbin-wasm")
 include(":samples:mockbin-native")
 
 pluginManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ include(":fuel-jackson-jvm")
 include(":fuel-kotlinx-serialization")
 include(":fuel-moshi-jvm")
 
-//include(":samples:httpbin-wasm")
+// include(":samples:httpbin-wasm")
 include(":samples:mockbin-native")
 
 pluginManagement {


### PR DESCRIPTION
This PR updates the project to Kotlin 2.1.0, the latest version as of now. As part of this update, JetBrains has moved the Kotlin WasmJS browser API out of the Kotlin standard library into a separate repository: [kotlinx-browser](https://github.com/Kotlin/kotlinx-browser).

However, the kotlinx-browser library is still a Work in Progress (WIP) and is not yet recommended for end-users. Given this, additional considerations may be needed before fully integrating it into production.