### PR TITLE
Fix OkHttp Headers

### DIFF
--- a/fuel/src/jvmMain/kotlin/fuel/OkHttpUtils.kt
+++ b/fuel/src/jvmMain/kotlin/fuel/OkHttpUtils.kt
@@ -52,5 +52,4 @@ public fun Call.performAsyncWithSSE(): Flow<String> =
         }
     }
 
-public fun Response.toHeaders(): Map<String, String> =
-    headers.names().associateWith { name -> headers[name] ?: "" }
+public fun Response.toHeaders(): Map<String, String> = headers.names().associateWith { name -> headers[name] ?: "" }

--- a/fuel/src/jvmMain/kotlin/fuel/OkHttpUtils.kt
+++ b/fuel/src/jvmMain/kotlin/fuel/OkHttpUtils.kt
@@ -52,4 +52,7 @@ public fun Call.performAsyncWithSSE(): Flow<String> =
         }
     }
 
-public fun Response.toHeaders(): Map<String, String> = headers.names().associateWith { name -> headers[name] ?: "" }
+public fun Response.toHeaders(): Map<String, String> =
+    headers.names().mapNotNull { name ->
+        headers[name]?.let { value -> name to value }
+    }.toMap()

--- a/fuel/src/jvmMain/kotlin/fuel/OkHttpUtils.kt
+++ b/fuel/src/jvmMain/kotlin/fuel/OkHttpUtils.kt
@@ -53,6 +53,8 @@ public fun Call.performAsyncWithSSE(): Flow<String> =
     }
 
 public fun Response.toHeaders(): Map<String, String> =
-    headers.names().mapNotNull { name ->
-        headers[name]?.let { value -> name to value }
-    }.toMap()
+    headers
+        .names()
+        .mapNotNull { name ->
+            headers[name]?.let { value -> name to value }
+        }.toMap()

--- a/fuel/src/jvmMain/kotlin/fuel/OkHttpUtils.kt
+++ b/fuel/src/jvmMain/kotlin/fuel/OkHttpUtils.kt
@@ -52,4 +52,5 @@ public fun Call.performAsyncWithSSE(): Flow<String> =
         }
     }
 
-public fun Response.toHeaders(): Map<String, String> = headers.toList().associate { (name, value) -> name to value }
+public fun Response.toHeaders(): Map<String, String> =
+    headers.names().associateWith { name -> headers[name] ?: "" }

--- a/fuel/src/jvmTest/kotlin/fuel/HttpLoaderBuilderTest.kt
+++ b/fuel/src/jvmTest/kotlin/fuel/HttpLoaderBuilderTest.kt
@@ -69,8 +69,7 @@ class HttpLoaderBuilderTest {
                     .get {
                         url = mockWebServer.url("hello").toString()
                     }.headers
-            assertEquals("1", response["Content-Length"])
-
+            assertEquals("11", response["Content-Length"])
             mockWebServer.shutdown()
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ serialization = "1.8.1"
 kotlinx-io = "0.7.0"
 kover = "0.9.1"
 kotlin = "2.1.20"
-ksp = "2.1.20-2.0.0"
+ksp = "2.1.20-2.0.1"
 
 [libraries]
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,8 +9,8 @@ result = "5.6.0"
 serialization = "1.8.1"
 kotlinx-io = "0.7.0"
 kover = "0.9.1"
-kotlin = "2.1.10"
-ksp = "2.1.20-1.0.31"
+kotlin = "2.1.20"
+ksp = "2.1.20-2.0.0"
 
 [libraries]
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
OkHttp's Headers expect Map<String, List<String>>
NSURLSession's Headers expect Map<String, String>>

I found a way to restore headers like NSURLSession. 